### PR TITLE
Fix bug in third party block serialization

### DIFF
--- a/Sources/Biscuits/Biscuit.swift
+++ b/Sources/Biscuits/Biscuit.swift
@@ -471,7 +471,7 @@ public struct Biscuit: Sendable, Hashable {
         }
         proto.authority = try self.authority.proto(interner: self.interner.primary)
         proto.blocks = try self.attenuations.enumerated().map {
-            try $1.proto(interner: self.interner.blockTable(for: $0))
+            try $1.proto(interner: self.interner.blockTable(for: $0 + 1))
         }
         proto.proof = self.proof.proto
         return proto


### PR DESCRIPTION
In the protobuf serialization code there was an off-by-one error in accessing the internment table for blocks which have a third party signature. Fixed this and added a test that would catch this error.