### PR TITLE
Test that biscuits roundtrip serialization

### DIFF
--- a/Tests/BiscuitsTests/GenerationTests.swift
+++ b/Tests/BiscuitsTests/GenerationTests.swift
@@ -27,6 +27,10 @@ final class GenerationTests: XCTestCase {
             XCTAssertEqual(expected.signedByThirdParty, block.signedByThirdParty)
             compareBlocks(expected.datalog, block.datalog)
         }
+
+        let serialized = try biscuit.serializedData()
+        let deserialized = try Biscuit(serializedData: serialized, rootKey: rootPublicKey)
+        XCTAssertEqual(biscuit, deserialized)
     }
 
     func compareBlocks(_ lhs: Biscuit.DatalogBlock, _ rhs: Biscuit.DatalogBlock) {


### PR DESCRIPTION
Every generated biscuit will now also be roundtripped through the serialization code to make sure it remains the same token