### PR TITLE
fix(doc): add trailing / in redirect rule

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [[redirects]]
   from = "/"
-  to = "/documentation/biscuits"
+  to = "/documentation/biscuits/"


### PR DESCRIPTION
netlify is redirecting from `/documentation/biscuits` to `/documentation/biscuits/` so we save an extra HTTP request