### PR TITLE
Refactor to keep serialized Datalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# `2.0.0`
+
+- Fix platform minimum versions being too low for iOS, tvOS, and watchOS
+- Declare support for visionOS
+- Declare support for SwiftCrypto version 4.0.0
+- Fix potential issue with non-canonical Datalog serialization
+- Fix `UnverifiedBiscuit` verification method not verifying final proof
+- Remove context argument from APIs that would let user set context in conflicting ways
+
 # `1.1.1`
 
 - Fix `secp256r1` signatures (#15)

--- a/Sources/Biscuits/Biscuit.swift
+++ b/Sources/Biscuits/Biscuit.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// A Biscuit authorization token
 public struct Biscuit: Sendable, Hashable {
-    let interner: InternmentTables
+    let interner: InternmentTable
     let proof: Proof
 
     /// The ID of the key used to sign the authority block of this Biscuit, if one is specified
@@ -37,11 +37,10 @@ public struct Biscuit: Sendable, Hashable {
         @DatalogBlock using datalog: () throws -> DatalogBlock
     ) throws {
         try self.init(
-            authorityBlock: datalog(),
+            authorityBlock: DatalogBlock(context: context, datalog),
             rootKey: rootKey,
             rootKeyID: rootKeyID,
             algorithm: algorithm,
-            context: context
         )
     }
 
@@ -63,11 +62,10 @@ public struct Biscuit: Sendable, Hashable {
         context: String? = nil
     ) throws {
         try self.init(
-            authorityBlock: DatalogBlock(datalog),
+            authorityBlock: DatalogBlock(datalog, context: context),
             rootKey: rootKey,
             rootKeyID: rootKeyID,
             algorithm: algorithm,
-            context: context
         )
     }
 
@@ -78,25 +76,21 @@ public struct Biscuit: Sendable, Hashable {
     ///   - rootKey: the key that will sign the authority block
     ///   - rootKeyID: the identifier of the rootKey
     ///   - algorithm: which signing algorithm to use to seal or attenuate this Biscuit
-    ///   - context: context information which can be carried with this Biscuit
     /// - Throws: Signing may throw an error
     public init<Key: PrivateKey>(
         authorityBlock: DatalogBlock,
         rootKey: Key,
         rootKeyID: RootKeyID? = nil,
         algorithm: SigningAlgorithm = .ed25519,
-        context: String? = nil
     ) throws {
-        var interner = InternmentTables()
-        var authority = authorityBlock
-        authority.attachToBiscuit(interner: &interner.primary, context: context)
+        var interner = InternmentTable()
         let nextKey = InternalPrivateKey(algorithm: algorithm)
         self.rootKeyID = rootKeyID
         self.authority = try Block(
-            datalog: authority,
+            datalog: authorityBlock,
             nextKey: nextKey.publicKey,
             key: rootKey,
-            interner: interner.primary
+            interner: &interner
         )
         self.interner = interner
         self.attenuations = []
@@ -137,24 +131,19 @@ public struct Biscuit: Sendable, Hashable {
         guard let rootKey = getRootKey(self.rootKeyID) else {
             throw ValidationError.unknownRootKey
         }
-        var interner = InternmentTables()
-        self.authority = try Block(
+        var interner = InternmentTable()
+        self.authority = try Block.authority(
             proto: proto.authority,
             key: rootKey,
             interner: &interner
         )
         var lastBlock = self.authority
-        self.attenuations = try proto.blocks.enumerated().map {
-            lastBlock = try Block(
-                proto: $1,
-                lastBlock: lastBlock,
-                blockID: $0 + 1,
-                interner: &interner
-            )
+        self.attenuations = try proto.blocks.map {
+            lastBlock = try Block.attenuation(proto: $0, lastBlock: lastBlock, interner: &interner)
             return lastBlock
         }
         self.proof = try Proof(proto: proto.proof, algorithm: lastBlock.nextKey.algorithm)
-        try self.proof.isValidProof(for: lastBlock, interner: interner.blockTable(for: self.attenuations.count))
+        try self.proof.isValidProof(for: lastBlock)
         self.interner = interner
     }
 
@@ -192,7 +181,7 @@ public struct Biscuit: Sendable, Hashable {
         try self.init(serializedData: data, getRootKey: getRootKey)
     }
 
-    init(_ parent: Biscuit, _ attenuations: [Block], _ interner: InternmentTables, _ proof: Proof) {
+    init(_ parent: Biscuit, _ attenuations: [Block], _ interner: InternmentTable, _ proof: Proof) {
         self.interner = interner
         self.rootKeyID = parent.rootKeyID
         self.authority = parent.authority
@@ -223,7 +212,7 @@ public struct Biscuit: Sendable, Hashable {
         context: String? = nil,
         @DatalogBlock using datalog: () throws -> DatalogBlock
     ) throws -> Biscuit {
-        try self.attenuated(using: datalog(), algorithm: algorithm, context: context)
+        try self.attenuated(using: DatalogBlock(context: context, datalog), algorithm: algorithm)
     }
 
     /// Attenuate this Biscuit, producing a new Biscuit which has been attenuated to a smaller
@@ -244,10 +233,9 @@ public struct Biscuit: Sendable, Hashable {
         @DatalogBlock using datalog: () throws -> DatalogBlock
     ) throws -> Biscuit {
         try self.attenuated(
-            using: datalog(),
+            using: DatalogBlock(context: context, datalog),
             thirdPartyKey: thirdPartyKey,
             algorithm: algorithm,
-            context: context
         )
     }
 
@@ -267,9 +255,8 @@ public struct Biscuit: Sendable, Hashable {
         context: String? = nil
     ) throws -> Biscuit {
         try self.attenuated(
-            using: DatalogBlock(datalog),
+            using: DatalogBlock(datalog, context: context),
             algorithm: algorithm,
-            context: context
         )
     }
 
@@ -291,10 +278,9 @@ public struct Biscuit: Sendable, Hashable {
         context: String? = nil
     ) throws -> Biscuit {
         try self.attenuated(
-            using: DatalogBlock(datalog),
+            using: DatalogBlock(datalog, context: context),
             thirdPartyKey: thirdPartyKey,
             algorithm: algorithm,
-            context: context
         )
     }
 
@@ -304,32 +290,26 @@ public struct Biscuit: Sendable, Hashable {
     /// - Parameters:
     ///   - datalog: the datalog contents of the attenuation, as a String
     ///   - algorithm: the algorithm that will be used to further attenuate the new Biscuit
-    ///   - context: context information which can be carried with the attenuation
     /// - Returns: the attenuated Biscuit
     /// - Throws: May throw an `AttenuationError` if the Biscuit is sealed or a `DatalogError` if
     /// the datalog string cannot be parsed, and signing may throw an error
     public func attenuated(
         using datalog: DatalogBlock,
         algorithm: SigningAlgorithm = .ed25519,
-        context: String? = nil
     ) throws -> Biscuit {
         guard case .nextSecret(let lastKey) = self.proof else {
             throw AttenuationError.cannotAttenuateSealedToken
         }
         var interner = self.interner
-        var attenuation = datalog
-        attenuation.attachToBiscuit(interner: &interner.primary, context: context)
         let nextKey = InternalPrivateKey(algorithm: algorithm)
-        let lastSig = self.attenuations.last?.signature ?? self.authority.signature
         var attenuations = self.attenuations
         try attenuations.append(
             Block(
-                datalog: attenuation,
+                datalog: datalog,
                 nextKey: nextKey.publicKey,
                 lastKey: lastKey,
-                lastSig: lastSig,
-                externalSignature: nil,
-                interner: interner.primary
+                lastSig: self.lastSig,
+                interner: &interner
             )
         )
         return Biscuit(self, attenuations, interner, .nextSecret(nextKey))
@@ -342,7 +322,6 @@ public struct Biscuit: Sendable, Hashable {
     ///   - datalog: the datalog contents of the attenuation
     ///   - thirdPartyKey: this key will be used to sign the attenuation
     ///   - algorithm: the algorithm that will be used to further attenuate the new Biscuit
-    ///   - context: context information which can be carried with the attenuation
     /// - Returns: the attenuated Biscuit
     /// - Throws: May throw an `AttenuationError` if the Biscuit is sealed and signing may throw an
     /// error
@@ -350,36 +329,22 @@ public struct Biscuit: Sendable, Hashable {
         using datalog: DatalogBlock,
         thirdPartyKey: Key,
         algorithm: SigningAlgorithm = .ed25519,
-        context: String? = nil
     ) throws -> Biscuit {
         guard case .nextSecret(let lastKey) = self.proof else {
             throw AttenuationError.cannotAttenuateSealedToken
         }
-        var blockInterner = BlockInternmentTable()
-        var attenuation = datalog
-        attenuation.attachToBiscuit(interner: &blockInterner, context: context)
         let nextKey = InternalPrivateKey(algorithm: algorithm)
-        let lastSig = self.attenuations.last?.signature ?? self.authority.signature
         var attenuations = self.attenuations
-        let externalSignature = try Block.ExternalSignature(
-            block: attenuation,
-            lastSig: lastSig,
-            thirdPartyKey: thirdPartyKey,
-            interner: blockInterner
-        )
         try attenuations.append(
             Block(
-                datalog: attenuation,
+                datalog: datalog,
                 nextKey: nextKey.publicKey,
                 lastKey: lastKey,
-                lastSig: lastSig,
-                externalSignature: externalSignature,
-                interner: blockInterner
+                lastSig: self.lastSig,
+                thirdPartyKey: thirdPartyKey,
             )
         )
-        var interner = self.interner
-        interner.setBlockTable(blockInterner, for: attenuations.count)
-        return Biscuit(self, attenuations, interner, .nextSecret(nextKey))
+        return Biscuit(self, attenuations, self.interner, .nextSecret(nextKey))
     }
 
     /// Seal this Biscuit, producing a new Biscuit which cannot be attenuated further. This Biscuit
@@ -389,10 +354,7 @@ public struct Biscuit: Sendable, Hashable {
     /// - Throws: Signing may throw an error
     public func sealed() throws -> Biscuit {
         if case .nextSecret(let key) = self.proof {
-            let sig = try key.sealingSignature(
-                for: self.attenuations.last ?? self.authority,
-                interner: self.interner.blockTable(for: self.attenuations.count)
-            )
+            let sig = try key.sealingSignature(for: self.attenuations.last ?? self.authority)
             return Biscuit(self, self.attenuations, self.interner, .finalSignature(sig))
         } else {
             return self
@@ -446,14 +408,14 @@ public struct Biscuit: Sendable, Hashable {
     /// - Returns: the data representation of this Biscuit
     /// - Throws: May throw an error if protobuf serialization fails
     public func serializedData() throws -> Data {
-        try self.proto().serializedData()
+        try self.proto.serializedData()
     }
 
     /// Serialize this Biscuit to its base64url encoded representation
     /// - Returns: the base64url encoded representation of this Biscuit
     /// - Throws: May thow an error if protobuf serialization fails
     public func base64URLEncoded() throws -> String {
-        let base64Encoded = try self.proto().serializedData().base64EncodedString()
+        let base64Encoded = try self.serializedData().base64EncodedString()
         // Translate base64 into base64url, ignoring padding, as defined in RFC4648.
         return
             base64Encoded
@@ -464,15 +426,13 @@ public struct Biscuit: Sendable, Hashable {
     /// Whether or not this Biscuit has been sealed
     public var isSealed: Bool { self.proof.isSealed }
 
-    func proto() throws -> Biscuit_Format_Schema_Biscuit {
+    var proto: Biscuit_Format_Schema_Biscuit {
         var proto = Biscuit_Format_Schema_Biscuit()
         if let rootKeyID = self.rootKeyID {
             proto.rootKeyID = rootKeyID.rawValue
         }
-        proto.authority = try self.authority.proto(interner: self.interner.primary)
-        proto.blocks = try self.attenuations.enumerated().map {
-            try $1.proto(interner: self.interner.blockTable(for: $0 + 1))
-        }
+        proto.authority = self.authority.proto
+        proto.blocks = self.attenuations.map { $0.proto }
         proto.proof = self.proof.proto
         return proto
     }
@@ -551,5 +511,9 @@ public struct Biscuit: Sendable, Hashable {
         limitedBy: Authorizer.Limits = Authorizer.Limits.noLimits
     ) throws -> Bool {
         try self.query(using: Check(datalog), limitedBy: limitedBy)
+    }
+
+    var lastSig: Data {
+        self.attenuations.last?.signature ?? self.authority.signature
     }
 }

--- a/Sources/Biscuits/Biscuit.swift
+++ b/Sources/Biscuits/Biscuit.swift
@@ -308,7 +308,7 @@ public struct Biscuit: Sendable, Hashable {
                 datalog: datalog,
                 nextKey: nextKey.publicKey,
                 lastKey: lastKey,
-                lastSig: self.lastSig,
+                lastSig: self.lastBlock.signature,
                 interner: &interner
             )
         )
@@ -340,7 +340,7 @@ public struct Biscuit: Sendable, Hashable {
                 datalog: datalog,
                 nextKey: nextKey.publicKey,
                 lastKey: lastKey,
-                lastSig: self.lastSig,
+                lastSig: self.lastBlock.signature,
                 thirdPartyKey: thirdPartyKey,
             )
         )
@@ -354,7 +354,7 @@ public struct Biscuit: Sendable, Hashable {
     /// - Throws: Signing may throw an error
     public func sealed() throws -> Biscuit {
         if case .nextSecret(let key) = self.proof {
-            let sig = try key.sealingSignature(for: self.attenuations.last ?? self.authority)
+            let sig = try key.sealingSignature(for: self.lastBlock)
             return Biscuit(self, self.attenuations, self.interner, .finalSignature(sig))
         } else {
             return self
@@ -513,7 +513,7 @@ public struct Biscuit: Sendable, Hashable {
         try self.query(using: Check(datalog), limitedBy: limitedBy)
     }
 
-    var lastSig: Data {
-        self.attenuations.last?.signature ?? self.authority.signature
+    var lastBlock: Block {
+        self.attenuations.last ?? self.authority
     }
 }

--- a/Sources/Biscuits/Block.swift
+++ b/Sources/Biscuits/Block.swift
@@ -15,20 +15,29 @@ extension Biscuit {
         public let datalog: DatalogBlock
         let nextKey: InternalPublicKey
         let version: UInt32?
-        var signature: Data
-        var externalSignature: ExternalSignature?
+        let serializedDatalog: Data
+        let signature: Data
+        let externalSignature: ExternalSignature?
 
         init<Key: PrivateKey>(
             datalog: DatalogBlock,
             nextKey: InternalPublicKey,
             key: Key,
-            interner: BlockInternmentTable
+            interner: inout InternmentTable
         ) throws {
             self.datalog = datalog
             self.nextKey = nextKey
             self.version = 1
-            self.signature = Data()
-            self.signature = try key.signature(for: self.signatureInput(interner: interner))
+            self.serializedDatalog = try datalog.serializeInBiscuit(interner: &interner)
+            self.externalSignature = nil
+            self.signature = try key.signature(
+                for: SignatureV1.blockSignatureInput(
+                    payload: self.serializedDatalog,
+                    nextKey: self.nextKey,
+                    prevSig: nil,
+                    externalSig: nil
+                )
+            )
         }
 
         init(
@@ -36,77 +45,162 @@ extension Biscuit {
             nextKey: InternalPublicKey,
             lastKey: InternalPrivateKey,
             lastSig: Data,
-            externalSignature: ExternalSignature?,
-            interner: BlockInternmentTable
+            interner: inout InternmentTable
         ) throws {
             self.datalog = datalog
             self.nextKey = nextKey
-            self.externalSignature = externalSignature
             self.version = 1
-            self.signature = Data()
-            let signatureInput = try self.signatureInput(interner: interner, lastSig: lastSig)
-            self.signature = try lastKey.signature(for: signatureInput)
+            self.serializedDatalog = try datalog.serializeInBiscuit(interner: &interner)
+            self.externalSignature = nil
+            self.signature = try lastKey.signature(
+                for: SignatureV1.blockSignatureInput(
+                    payload: self.serializedDatalog,
+                    nextKey: self.nextKey,
+                    prevSig: lastSig,
+                    externalSig: nil
+                )
+            )
         }
 
-        // for the authority block
-        init<Key: PublicKey>(
+        init<Key: PrivateKey>(
+            datalog: DatalogBlock,
+            nextKey: InternalPublicKey,
+            lastKey: InternalPrivateKey,
+            lastSig: Data,
+            thirdPartyKey: Key,
+        ) throws {
+            var interner = InternmentTable()
+            self.datalog = datalog
+            self.nextKey = nextKey
+            self.version = 1
+            self.serializedDatalog = try datalog.serializeInBiscuit(interner: &interner)
+            self.externalSignature = try ExternalSignature(
+                block: self.serializedDatalog,
+                lastSig: lastSig,
+                thirdPartyKey: thirdPartyKey,
+            )
+            self.signature = try lastKey.signature(
+                for: SignatureV1.blockSignatureInput(
+                    payload: self.serializedDatalog,
+                    nextKey: self.nextKey,
+                    prevSig: lastSig,
+                    externalSig: self.externalSignature?.signature
+                )
+            )
+        }
+
+        init(
+            contents: ThirdPartyBlockContents,
+            nextKey: InternalPublicKey,
+            lastKey: InternalPrivateKey,
+            lastSig: Data
+        ) throws {
+            self.datalog = contents.payload
+            self.serializedDatalog = contents.serializedPayload
+            self.nextKey = nextKey
+            self.externalSignature = contents.externalSignature
+            self.version = 1
+            self.signature = try lastKey.signature(
+                for: SignatureV1.blockSignatureInput(
+                    payload: self.serializedDatalog,
+                    nextKey: self.nextKey,
+                    prevSig: lastSig,
+                    externalSig: self.externalSignature?.signature
+                )
+            )
+        }
+
+        static func authority<Key: PublicKey>(
             proto: Biscuit_Format_Schema_SignedBlock,
             key: Key,
-            interner: inout InternmentTables
-        ) throws {
-            self = try Block.init(proto: proto, interner: &interner)
-            let signatureInput = try self.signatureInput(interner: interner.primary)
-            guard key.isValidSignature(self.signature, for: signatureInput) else {
+            interner: inout InternmentTable
+        ) throws -> Block {
+            let block = try Block.unverifiedAuthority(proto: proto, interner: &interner)
+            guard key.isValidSignature(block.signature, for: block.signatureInput()) else {
                 throw ValidationError.invalidSignature
             }
+            return block
         }
 
-        // for attenuation blocks
-        init(
+        static func attenuation(
             proto: Biscuit_Format_Schema_SignedBlock,
             lastBlock: Block,
-            blockID: Int,
-            interner: inout InternmentTables
-        ) throws {
-            self = try Block.init(proto: proto, blockID: blockID, interner: &interner)
-            let blockInterner = interner.blockTable(for: blockID)
-            let signatureInput = try self.signatureInput(interner: blockInterner, lastSig: lastBlock.signature)
-            guard lastBlock.nextKey.isValidSignature(self.signature, for: signatureInput) else {
+            interner: inout InternmentTable
+        ) throws -> Block {
+            let block = try Block.unverifiedAttenuation(proto: proto, interner: &interner)
+            if let externalSignature = block.externalSignature {
+                try externalSignature.isValidSignature(for: block, lastSig: lastBlock.signature)
+            }
+            let signatureInput = block.signatureInput(lastSig: lastBlock.signature)
+            guard lastBlock.nextKey.isValidSignature(block.signature, for: signatureInput) else {
                 throw ValidationError.invalidSignature
             }
-            if let externalSignature = self.externalSignature {
-                try externalSignature.isValidSignature(for: self, lastSig: lastBlock.signature, interner: blockInterner)
-            }
+            return block
         }
 
-        init(proto: Biscuit_Format_Schema_SignedBlock, interner: inout InternmentTables) throws {
+        static func unverifiedAuthority(
+            proto: Biscuit_Format_Schema_SignedBlock,
+            interner: inout InternmentTable
+        ) throws -> Block {
             try Self.checkProto(proto: proto)
             guard !proto.hasExternalSignature else {
                 throw ValidationError.thirdPartySignedAuthority
             }
-            self.nextKey = try InternalPublicKey(proto: proto.nextKey)
-            self.version = proto.hasVersion ? proto.version : nil
-            self.signature = proto.signature
-            self.datalog = try DatalogBlock(serializedData: proto.block, &interner.primary)
+            return Block(
+                datalog: try DatalogBlock(serializedData: proto.block, &interner),
+                nextKey: try InternalPublicKey(proto: proto.nextKey),
+                version: proto.hasVersion ? proto.version : nil,
+                serializedDatalog: proto.block,
+                signature: proto.signature,
+                externalSignature: nil
+            )
         }
 
-        init(proto: Biscuit_Format_Schema_SignedBlock, blockID: Int, interner: inout InternmentTables) throws {
+        static func unverifiedAttenuation(
+            proto: Biscuit_Format_Schema_SignedBlock,
+            interner: inout InternmentTable
+        ) throws -> Block {
             try Self.checkProto(proto: proto)
-            self.nextKey = try InternalPublicKey(proto: proto.nextKey)
-            self.version = proto.hasVersion ? proto.version : nil
-            self.signature = proto.signature
+            let version = proto.hasVersion ? proto.version : nil
             if proto.hasExternalSignature {
-                guard self.version ?? 0 >= 1 else {
+                guard version ?? 0 >= 1 else {
                     throw ValidationError.deprecatedThirdPartySignature
                 }
-                var blockInterner = BlockInternmentTable()
-                self.datalog = try DatalogBlock(serializedData: proto.block, &blockInterner)
-                let externalSignature = try ExternalSignature(proto: proto.externalSignature)
-                self.externalSignature = externalSignature
-                interner.setBlockTable(blockInterner, for: blockID)
+                var blockInterner = InternmentTable()
+                return Block(
+                    datalog: try DatalogBlock(serializedData: proto.block, &blockInterner),
+                    nextKey: try InternalPublicKey(proto: proto.nextKey),
+                    version: version,
+                    serializedDatalog: proto.block,
+                    signature: proto.signature,
+                    externalSignature: try ExternalSignature(proto: proto.externalSignature)
+                )
             } else {
-                self.datalog = try DatalogBlock(serializedData: proto.block, &interner.primary)
+                return Block(
+                    datalog: try DatalogBlock(serializedData: proto.block, &interner),
+                    nextKey: try InternalPublicKey(proto: proto.nextKey),
+                    version: version,
+                    serializedDatalog: proto.block,
+                    signature: proto.signature,
+                    externalSignature: nil
+                )
             }
+        }
+
+        fileprivate init(
+            datalog: DatalogBlock,
+            nextKey: InternalPublicKey,
+            version: UInt32?,
+            serializedDatalog: Data,
+            signature: Data,
+            externalSignature: ExternalSignature?
+        ) {
+            self.datalog = datalog
+            self.nextKey = nextKey
+            self.version = version
+            self.serializedDatalog = serializedDatalog
+            self.signature = signature
+            self.externalSignature = externalSignature
         }
 
         static func checkProto(proto: Biscuit_Format_Schema_SignedBlock) throws {
@@ -131,14 +225,14 @@ extension Biscuit {
             self.signature
         }
 
-        func proto(interner: BlockInternmentTable) throws -> Biscuit_Format_Schema_SignedBlock {
+        var proto: Biscuit_Format_Schema_SignedBlock {
             var proto = Biscuit_Format_Schema_SignedBlock()
             proto.signature = self.signature
             proto.nextKey = self.nextKey.proto
             if let version = self.version {
                 proto.version = UInt32(version)
             }
-            proto.block = try self.datalog.serializedData(interner)
+            proto.block = self.serializedDatalog
             if let externalSignature = self.externalSignature {
                 proto.externalSignature = externalSignature.proto
             }
@@ -150,15 +244,15 @@ extension Biscuit {
         /// The third party key that signed this block, if it exists
         public var thirdPartyKey: ThirdPartyKey? { self.externalSignature?.publicKey }
 
-        func signatureInput(interner: BlockInternmentTable, lastSig: Data? = nil) throws -> Data {
+        func signatureInput(lastSig: Data? = nil) -> Data {
             switch self.version ?? 0 {
-            case 0: return try SignatureV0.blockSignatureInput(block: self, interner: interner)
-            default: return try SignatureV1.blockSignatureInput(block: self, sig: lastSig, interner: interner)
+            case 0: return SignatureV0.blockSignatureInput(block: self)
+            default: return SignatureV1.blockSignatureInput(block: self, sig: lastSig)
             }
         }
 
-        func sealingSignatureInput(interner: BlockInternmentTable) throws -> Data {
-            try SignatureV0.sealingSignatureInput(block: self, interner: interner)
+        func sealingSignatureInput() -> Data {
+            SignatureV0.sealingSignatureInput(block: self)
         }
 
         struct ExternalSignature: Hashable {
@@ -166,12 +260,11 @@ extension Biscuit {
             var publicKey: ThirdPartyKey
 
             init<Key: PrivateKey>(
-                block: DatalogBlock,
+                block: Data,
                 lastSig: Data,
                 thirdPartyKey: Key,
-                interner: BlockInternmentTable
             ) throws {
-                let input = try SignatureV1.externalSignatureInput(block: block, sig: lastSig, interner: interner)
+                let input = SignatureV1.externalSignatureInput(block: block, sig: lastSig)
                 self.signature = try thirdPartyKey.signature(for: input)
                 self.publicKey = ThirdPartyKey(key: thirdPartyKey.publicKey)
             }
@@ -187,12 +280,11 @@ extension Biscuit {
                 self.publicKey = ThirdPartyKey(proto: proto.publicKey)
             }
 
-            func isValidSignature(for block: Block, lastSig: Data, interner: BlockInternmentTable) throws {
+            func isValidSignature(for block: Block, lastSig: Data) throws {
                 try self.publicKey.isValidExternalSignature(
                     self.signature,
                     for: block,
                     lastSig: lastSig,
-                    interner: interner
                 )
             }
 

--- a/Sources/Biscuits/Crypto/InternalKeys.swift
+++ b/Sources/Biscuits/Crypto/InternalKeys.swift
@@ -38,8 +38,8 @@ extension Biscuit {
             }
         }
 
-        func sealingSignature(for block: Block, interner: BlockInternmentTable) throws -> Data {
-            try self.signature(for: block.sealingSignatureInput(interner: interner))
+        func sealingSignature(for block: Block) throws -> Data {
+            try self.signature(for: block.sealingSignatureInput())
         }
 
         static func == (lhs: InternalPrivateKey, rhs: InternalPrivateKey) -> Bool {
@@ -124,14 +124,14 @@ extension Biscuit {
             }
         }
 
-        func isValidSignature(for block: Block, interner: BlockInternmentTable) throws {
-            guard try self.isValidSignature(block.signature, for: block.signatureInput(interner: interner)) else {
+        func isValidSignature(for block: Block) throws {
+            guard self.isValidSignature(block.signature, for: block.signatureInput()) else {
                 throw ValidationError.invalidSignature
             }
         }
 
-        func isValidSealingSignature(_ signature: Data, for block: Block, interner: BlockInternmentTable) throws {
-            guard try self.isValidSignature(signature, for: block.sealingSignatureInput(interner: interner)) else {
+        func isValidSealingSignature(_ signature: Data, for block: Block) throws {
+            guard self.isValidSignature(signature, for: block.sealingSignatureInput()) else {
                 throw ValidationError.invalidSealingSignature
             }
         }

--- a/Sources/Biscuits/Crypto/Signature.swift
+++ b/Sources/Biscuits/Crypto/Signature.swift
@@ -21,33 +21,43 @@ struct SignatureV1 {
     fileprivate static let ed25519: Data = Data("\0ALGORITHM\0\0\0\0\0".utf8)
     fileprivate static let secp256r1: Data = Data("\0ALGORITHM\0\u{1}\0\0\0".utf8)
 
-    static func externalSignatureInput(
-        block: Biscuit.DatalogBlock,
-        sig: Data,
-        interner: BlockInternmentTable
-    ) throws -> Data {
+    static func externalSignatureInput(block: Data, sig: Data) -> Data {
         var data = SignatureV1.external
         data.append(contentsOf: SignatureV1.version1)
         data.append(contentsOf: SignatureV1.payload)
-        try data.append(contentsOf: block.serializedData(interner))
+        data.append(contentsOf: block)
         data.append(contentsOf: SignatureV1.prevsig)
         data.append(contentsOf: sig)
         return data
     }
 
-    static func blockSignatureInput(block: Biscuit.Block, sig: Data?, interner: BlockInternmentTable) throws -> Data {
+    static func blockSignatureInput(block: Biscuit.Block, sig: Data?) -> Data {
+        Self.blockSignatureInput(
+            payload: block.serializedDatalog,
+            nextKey: block.nextKey,
+            prevSig: sig,
+            externalSig: block.externalSignature?.signature
+        )
+    }
+
+    static func blockSignatureInput(
+        payload: Data,
+        nextKey: Biscuit.InternalPublicKey,
+        prevSig: Data?,
+        externalSig: Data?
+    ) -> Data {
         var data = SignatureV1.block
         data.append(contentsOf: SignatureV1.version1)
         data.append(contentsOf: SignatureV1.payload)
-        try data.append(contentsOf: block.datalog.serializedData(interner))
-        data.append(contentsOf: SignatureV1.algorithm(for: block.nextKey.algorithm))
+        data.append(contentsOf: payload)
+        data.append(contentsOf: SignatureV1.algorithm(for: nextKey.algorithm))
         data.append(contentsOf: SignatureV1.nextkey)
-        data.append(contentsOf: block.nextKey.dataRepresentation)
-        if let sig = sig {
+        data.append(contentsOf: nextKey.dataRepresentation)
+        if let sig = prevSig {
             data.append(contentsOf: SignatureV1.prevsig)
             data.append(contentsOf: sig)
         }
-        if let sig = block.externalSignature?.signature {
+        if let sig = externalSig {
             data.append(contentsOf: SignatureV1.externalsig)
             data.append(contentsOf: sig)
         }
@@ -63,8 +73,8 @@ struct SignatureV1 {
 }
 
 struct SignatureV0 {
-    static func blockSignatureInput(block: Biscuit.Block, interner: BlockInternmentTable) throws -> Data {
-        var data = try block.datalog.serializedData(interner)
+    static func blockSignatureInput(block: Biscuit.Block) -> Data {
+        var data = block.serializedDatalog
         if let externalSignature = block.externalSignature {
             data.append(contentsOf: externalSignature.signature)
         }
@@ -73,8 +83,8 @@ struct SignatureV0 {
         return data
     }
 
-    static func sealingSignatureInput(block: Biscuit.Block, interner: BlockInternmentTable) throws -> Data {
-        var data = try block.datalog.serializedData(interner)
+    static func sealingSignatureInput(block: Biscuit.Block) -> Data {
+        var data = block.serializedDatalog
         data.append(contentsOf: algorithm(for: block.nextKey.algorithm))
         data.append(contentsOf: block.nextKey.dataRepresentation)
         data.append(contentsOf: block.signature)

--- a/Sources/Biscuits/Crypto/ThirdPartyKey.swift
+++ b/Sources/Biscuits/Crypto/ThirdPartyKey.swift
@@ -64,9 +64,8 @@ extension Biscuit {
             _ signature: Data,
             for block: Block,
             lastSig: Data,
-            interner: BlockInternmentTable
         ) throws {
-            let input = try SignatureV1.externalSignatureInput(block: block.datalog, sig: lastSig, interner: interner)
+            let input = SignatureV1.externalSignatureInput(block: block.serializedDatalog, sig: lastSig)
             switch self.algorithm.wrapped {
             case .ed25519:
                 let key = try Curve25519.Signing.PublicKey(rawRepresentation: self.dataRepresentation)

--- a/Sources/Biscuits/Datalog/Check.swift
+++ b/Sources/Biscuits/Datalog/Check.swift
@@ -113,7 +113,7 @@ public struct Check: Sendable, Hashable, CustomStringConvertible {
         self.queries = queries
     }
 
-    init(proto: Biscuit_Format_Schema_Check, interner: BlockInternmentTable) throws {
+    init(proto: Biscuit_Format_Schema_Check, interner: InternmentTable) throws {
         self.queries = try proto.queries.map { try Biscuit.Query(proto: $0, interner: interner) }
         if proto.hasKind {
             self._kind =
@@ -132,18 +132,12 @@ public struct Check: Sendable, Hashable, CustomStringConvertible {
     }
 
     func intern(
-        _ interner: inout BlockInternmentTable,
+        _ interner: inout InternmentTable,
         _ symbols: inout [String],
         _ publicKeys: inout [Biscuit.ThirdPartyKey]
-    ) {
-        for query in self.queries {
-            query.intern(&interner, &symbols, &publicKeys)
-        }
-    }
-
-    func proto(_ interner: BlockInternmentTable) -> Biscuit_Format_Schema_Check {
+    ) -> Biscuit_Format_Schema_Check {
         var proto = Biscuit_Format_Schema_Check()
-        proto.queries = self.queries.map { $0.proto(interner) }
+        proto.queries = self.queries.map { $0.intern(&interner, &symbols, &publicKeys) }
         if let kind = self._kind {
             proto.kind =
                 switch kind.wrapped {

--- a/Sources/Biscuits/Datalog/Closure.swift
+++ b/Sources/Biscuits/Datalog/Closure.swift
@@ -17,7 +17,7 @@ public struct Closure: Sendable, Hashable, CustomStringConvertible {
         self.ops = body.expression.ops
     }
 
-    init(proto: Biscuit_Format_Schema_OpClosure, interner: BlockInternmentTable) throws {
+    init(proto: Biscuit_Format_Schema_OpClosure, interner: InternmentTable) throws {
         self.params = try proto.params.map { try interner.lookupSymbol(Int($0)) }
         self.ops = try proto.ops.map { try Op(proto: $0, interner: interner) }
     }
@@ -90,19 +90,10 @@ public struct Closure: Sendable, Hashable, CustomStringConvertible {
         }
     }
 
-    func intern(_ interner: inout BlockInternmentTable, _ locals: inout [String]) {
-        for param in self.params {
-            interner.intern(param, &locals)
-        }
-        for op in self.ops {
-            op.intern(&interner, &locals)
-        }
-    }
-
-    func proto(_ interner: BlockInternmentTable) -> Biscuit_Format_Schema_OpClosure {
+    func intern(_ interner: inout InternmentTable, _ locals: inout [String]) -> Biscuit_Format_Schema_OpClosure {
         var proto = Biscuit_Format_Schema_OpClosure()
-        proto.params = self.params.map { UInt32(interner.symbolIndex(for: $0)) }
-        proto.ops = self.ops.map { $0.proto(interner) }
+        proto.params = self.params.map { UInt32(interner.intern($0, &locals)) }
+        proto.ops = self.ops.map { $0.intern(&interner, &locals) }
         return proto
     }
 

--- a/Sources/Biscuits/Datalog/DatalogBlock.swift
+++ b/Sources/Biscuits/Datalog/DatalogBlock.swift
@@ -12,9 +12,6 @@ extension Biscuit {
     /// A block of Datalog that can be included as part of a Biscuit
     @resultBuilder
     public struct DatalogBlock: Sendable, Hashable, CustomStringConvertible {
-        var version: UInt32
-        var symbols: [String]
-        var publicKeys: [Biscuit.ThirdPartyKey]
         /// The context string of this block, if one was specified
         public var context: String?
         /// The checks contained in this block
@@ -33,9 +30,6 @@ extension Biscuit {
             trusted: [TrustedScope] = [],
             context: String? = nil
         ) {
-            self.version = 6
-            self.symbols = []
-            self.publicKeys = []
             self.context = context
             self.checks = checks
             self.facts = facts
@@ -48,7 +42,11 @@ extension Biscuit {
         /// - Parameter context: the context that will be included with this DatalogBlock
         /// - Parameter datalog: the Datalog contents of this DatalogBlock
         public init(context: String? = nil, @DatalogBlock _ datalog: () throws -> DatalogBlock) rethrows {
-            self = try datalog()
+            let datalog = try datalog()
+            self.checks = datalog.checks
+            self.facts = datalog.facts
+            self.rules = datalog.rules
+            self.trusted = datalog.trusted
             self.context = context
         }
 
@@ -58,9 +56,6 @@ extension Biscuit {
         /// - Parameter datalog: the Datalog contents of this DatalogBlock as a String
         public init(_ datalog: String, context: String? = nil) throws {
             let parser = try Parser.forDatalogBlock(using: datalog)
-            self.version = 6
-            self.symbols = parser.symbols
-            self.publicKeys = parser.publicKeys
             self.checks = parser.checks
             self.facts = parser.facts
             self.rules = parser.rules
@@ -124,26 +119,24 @@ extension Biscuit {
             return [trusting, facts, rules, checks].joined(separator: "\n")
         }
 
-        mutating func attachToBiscuit(interner: inout BlockInternmentTable, context: String?) {
-            for trusted in self.trusted {
-                trusted.intern(&interner, &self.publicKeys)
+        func serializeInBiscuit(interner: inout InternmentTable) throws -> Data {
+            var proto = Biscuit_Format_Schema_Block()
+            var symbols: [String] = []
+            var publicKeys: [ThirdPartyKey] = []
+            if let context = self.context {
+                proto.context = context
             }
-            for fact in self.facts {
-                fact.intern(&interner, &self.symbols)
-            }
-            for rule in self.rules {
-                rule.intern(&interner, &self.symbols, &self.publicKeys)
-            }
-            for check in self.checks {
-                check.intern(&interner, &self.symbols, &self.publicKeys)
-            }
-            self.context = (self.context ?? "") + (context ?? "")
-            if self.context == "" {
-                self.context = nil
-            }
+            proto.version = 6
+            proto.scope = self.trusted.map { $0.intern(&interner, &publicKeys) }
+            proto.facts = self.facts.map { $0.intern(&interner, &symbols) }
+            proto.rules = self.rules.map { $0.intern(&interner, &symbols, &publicKeys) }
+            proto.checks = self.checks.map { $0.intern(&interner, &symbols, &publicKeys) }
+            proto.symbols = symbols
+            proto.publicKeys = publicKeys.map { $0.proto }
+            return try proto.serializedData()
         }
 
-        init(serializedData data: Data, _ interner: inout BlockInternmentTable) throws {
+        init(serializedData data: Data, _ interner: inout InternmentTable) throws {
             let proto = try Biscuit_Format_Schema_Block(serializedBytes: data)
             guard proto.hasVersion else {
                 throw Biscuit.ValidationError.missingVersion
@@ -151,40 +144,18 @@ extension Biscuit {
             guard proto.version >= 3 && proto.version <= 6 else {
                 throw Biscuit.ValidationError.invalidVersion
             }
-            self.version = proto.version
-            self.symbols = proto.symbols
-            self.publicKeys = proto.publicKeys.map { Biscuit.ThirdPartyKey(proto: $0) }
-            try interner.extend(self.symbols, self.publicKeys)
+            let symbols = proto.symbols
+            let publicKeys = proto.publicKeys.map { Biscuit.ThirdPartyKey(proto: $0) }
+            try interner.extend(symbols, publicKeys)
             if proto.hasContext {
                 self.context = proto.context
+            } else {
+                self.context = nil
             }
             self.checks = try proto.checks.map { try Check(proto: $0, interner: interner) }
             self.facts = try proto.facts.map { try Fact(proto: $0.predicate, interner: interner) }
             self.rules = try proto.rules.map { try Rule(proto: $0, interner: interner) }
             self.trusted = try proto.scope.map { try TrustedScope(proto: $0, interner: interner) }
-        }
-
-        func serializedData(_ interner: BlockInternmentTable) throws -> Data {
-            try self.proto(interner).serializedData()
-        }
-
-        func proto(_ interner: BlockInternmentTable) -> Biscuit_Format_Schema_Block {
-            var proto = Biscuit_Format_Schema_Block()
-            proto.symbols = self.symbols
-            if let context = self.context {
-                proto.context = context
-            }
-            proto.version = self.version
-            proto.checks = self.checks.map { $0.proto(interner) }
-            proto.facts = self.facts.map {
-                var fact = Biscuit_Format_Schema_Fact()
-                fact.predicate = $0.proto(interner)
-                return fact
-            }
-            proto.rules = self.rules.map { $0.proto(interner) }
-            proto.scope = self.trusted.map { $0.proto(interner) }
-            proto.publicKeys = self.publicKeys.map { $0.proto }
-            return proto
         }
     }
 }

--- a/Sources/Biscuits/Datalog/Expression.swift
+++ b/Sources/Biscuits/Datalog/Expression.swift
@@ -12,7 +12,7 @@ import Foundation
 public struct Expression: ExpressionConvertible, Sendable, Hashable, CustomStringConvertible {
     let ops: [Op]
 
-    init(proto: Biscuit_Format_Schema_Expression, interner: BlockInternmentTable) throws {
+    init(proto: Biscuit_Format_Schema_Expression, interner: InternmentTable) throws {
         self.ops = try proto.ops.map { try Op(proto: $0, interner: interner) }
     }
 
@@ -202,12 +202,6 @@ public struct Expression: ExpressionConvertible, Sendable, Hashable, CustomStrin
         Expression(op: .tryOr, lhs: Closure(body: self), rhs: rhs.expression)
     }
 
-    func proto(_ interner: BlockInternmentTable) -> Biscuit_Format_Schema_Expression {
-        var proto = Biscuit_Format_Schema_Expression()
-        proto.ops = self.ops.map { $0.proto(interner) }
-        return proto
-    }
-
     func evaluate(_ variables: [String: Value]) throws -> Bool {
         var stack: [StackElement] = []
         for op in self.ops {
@@ -243,10 +237,10 @@ public struct Expression: ExpressionConvertible, Sendable, Hashable, CustomStrin
         }
     }
 
-    func intern(_ interner: inout BlockInternmentTable, _ locals: inout [String]) {
-        for op in self.ops {
-            op.intern(&interner, &locals)
-        }
+    func intern(_ interner: inout InternmentTable, _ locals: inout [String]) -> Biscuit_Format_Schema_Expression {
+        var proto = Biscuit_Format_Schema_Expression()
+        proto.ops = self.ops.map { $0.intern(&interner, &locals) }
+        return proto
     }
 
     public var expression: Expression { self }
@@ -263,7 +257,7 @@ enum Op: Sendable, Hashable {
     case binary(OpBinary)
     case closure(Closure)
 
-    init(proto: Biscuit_Format_Schema_Op, interner: BlockInternmentTable) throws {
+    init(proto: Biscuit_Format_Schema_Op, interner: InternmentTable) throws {
         self =
             switch proto.content {
             case .value(let term): try .value(Term(proto: term, interner: interner))
@@ -274,21 +268,13 @@ enum Op: Sendable, Hashable {
             }
     }
 
-    func intern(_ interner: inout BlockInternmentTable, _ locals: inout [String]) {
-        switch self {
-        case .value(let term): term.intern(&interner, &locals)
-        case .closure(let closure): closure.intern(&interner, &locals)
-        default: return
-        }
-    }
-
-    func proto(_ interner: BlockInternmentTable) -> Biscuit_Format_Schema_Op {
+    func intern(_ interner: inout InternmentTable, _ locals: inout [String]) -> Biscuit_Format_Schema_Op {
         var proto = Biscuit_Format_Schema_Op()
         switch self {
-        case .value(let term): proto.value = term.proto(interner)
-        case .unary(let op_unary): proto.unary = op_unary.proto(interner)
-        case .binary(let op_binary): proto.binary = op_binary.proto(interner)
-        case .closure(let op_closure): proto.closure = op_closure.proto(interner)
+        case .value(let term): proto.value = term.intern(&interner, &locals)
+        case .unary(let op_unary): proto.unary = op_unary.intern(&interner, &locals)
+        case .binary(let op_binary): proto.binary = op_binary.intern(&interner, &locals)
+        case .closure(let op_closure): proto.closure = op_closure.intern(&interner, &locals)
         }
         return proto
     }

--- a/Sources/Biscuits/Datalog/Fact.swift
+++ b/Sources/Biscuits/Datalog/Fact.swift
@@ -45,7 +45,7 @@ public struct Fact: Sendable, Hashable, CustomStringConvertible {
         self.values = [index.value, revocationID.value]
     }
 
-    init(proto: Biscuit_Format_Schema_Predicate, interner: BlockInternmentTable) throws {
+    init(proto: Biscuit_Format_Schema_Predicate, interner: InternmentTable) throws {
         guard proto.hasName else {
             throw Biscuit.ValidationError.missingPredicate
         }
@@ -53,17 +53,11 @@ public struct Fact: Sendable, Hashable, CustomStringConvertible {
         self.values = try proto.terms.map { try Value(proto: $0, interner: interner) }
     }
 
-    func intern(_ interner: inout BlockInternmentTable, _ locals: inout [String]) {
-        interner.intern(self.name, &locals)
-        for values in self.values {
-            values.intern(&interner, &locals)
-        }
-    }
-
-    func proto(_ interner: BlockInternmentTable) -> Biscuit_Format_Schema_Predicate {
-        var proto = Biscuit_Format_Schema_Predicate()
-        proto.name = UInt64(interner.symbolIndex(for: self.name))
-        proto.terms = self.values.map { $0.proto(interner) }
+    func intern(_ interner: inout InternmentTable, _ locals: inout [String]) -> Biscuit_Format_Schema_Fact {
+        var proto = Biscuit_Format_Schema_Fact()
+        proto.predicate = Biscuit_Format_Schema_Predicate()
+        proto.predicate.name = UInt64(interner.intern(self.name, &locals))
+        proto.predicate.terms = self.values.map { $0.intern(&interner, &locals) }
         return proto
     }
 

--- a/Sources/Biscuits/Datalog/InternmentTable.swift
+++ b/Sources/Biscuits/Datalog/InternmentTable.swift
@@ -2,39 +2,16 @@
  * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * SPDX-License-Identifier: Apache-2.0
  */
-struct InternmentTables: Sendable, Hashable {
-    var primary: BlockInternmentTable = BlockInternmentTable()
-    var thirdPartyTables: [Int: BlockInternmentTable] = [:]
 
-    subscript(index: Resolution.Scope) -> BlockInternmentTable {
-        get {
-            if let blockID = index.blockID {
-                self.blockTable(for: blockID)
-            } else {
-                self.primary
-            }
-        }
-    }
-
-    func blockTable(for blockID: Int) -> BlockInternmentTable {
-        self.thirdPartyTables[blockID] ?? self.primary
-    }
-
-    mutating func setBlockTable(_ table: BlockInternmentTable, for blockID: Int) {
-        self.thirdPartyTables[blockID] = table
-    }
-}
-
-struct BlockInternmentTable: Sendable, Hashable {
-    var symbols: InternmentTable<String> = InternmentTable()
-    var publicKeys: InternmentTable<Biscuit.ThirdPartyKey> = InternmentTable()
+struct InternmentTable: Sendable, Hashable {
+    var symbols: InternmentTableInner<String> = InternmentTableInner()
+    var publicKeys: InternmentTableInner<Biscuit.ThirdPartyKey> = InternmentTableInner()
 
     mutating func extend(_ symbols: [String], _ publicKeys: [Biscuit.ThirdPartyKey]) throws {
         try self.symbols.extend(symbols, Biscuit.ValidationError.duplicateSymbol)
         try self.publicKeys.extend(publicKeys, Biscuit.ValidationError.duplicatePublicKey)
     }
 
-    @discardableResult
     mutating func intern(_ symbol: String, _ locals: inout [String]) -> Int {
         if let idx = defaultSymbols[symbol] {
             return idx
@@ -43,7 +20,6 @@ struct BlockInternmentTable: Sendable, Hashable {
         }
     }
 
-    @discardableResult
     mutating func intern(_ publicKey: Biscuit.ThirdPartyKey, _ locals: inout [Biscuit.ThirdPartyKey]) -> Int {
         self.publicKeys.intern(publicKey, &locals)
     }
@@ -78,7 +54,7 @@ struct BlockInternmentTable: Sendable, Hashable {
         }
     }
 
-    struct InternmentTable<T: Sendable & Hashable>: Sendable, Hashable {
+    struct InternmentTableInner<T: Sendable & Hashable>: Sendable, Hashable {
         var table: [T: Int] = [:]
         var array: [T] = []
 

--- a/Sources/Biscuits/Datalog/MapKey.swift
+++ b/Sources/Biscuits/Datalog/MapKey.swift
@@ -18,7 +18,7 @@ public struct MapKey: MapKeyConvertible, ValueConvertible, TermConvertible, Expr
     }
     let wrapped: Wrapped
 
-    init(proto: Biscuit_Format_Schema_MapKey, interner: BlockInternmentTable) throws {
+    init(proto: Biscuit_Format_Schema_MapKey, interner: InternmentTable) throws {
         self.wrapped =
             switch proto.content {
             case .integer(let i): .integer(i)
@@ -41,26 +41,10 @@ public struct MapKey: MapKeyConvertible, ValueConvertible, TermConvertible, Expr
         self.wrapped = wrapped
     }
 
-    // Intentionally not public and MapKey does not conform to Comparable
-    static func < (lhs: MapKey, rhs: MapKey) -> Bool {
-        switch (lhs.wrapped, rhs.wrapped) {
-        case (.integer(let l), .integer(let r)): return l < r
-        case (.string(let l), .string(let r)): return l < r
-        case (.integer, .string): return true
-        case (.string, .integer): return false
-        }
-    }
-
-    func intern(_ interner: inout BlockInternmentTable, _ locals: inout [String]) {
-        if case .string(let s) = self.wrapped {
-            interner.intern(s, &locals)
-        }
-    }
-
-    func proto(_ interner: BlockInternmentTable) -> Biscuit_Format_Schema_MapKey {
+    func intern(_ interner: inout InternmentTable, _ locals: inout [String]) -> Biscuit_Format_Schema_MapKey {
         var proto = Biscuit_Format_Schema_MapKey()
         switch self.wrapped {
-        case .string(let s): proto.string = UInt64(interner.symbolIndex(for: s))
+        case .string(let s): proto.string = UInt64(interner.intern(s, &locals))
         case .integer(let i): proto.integer = Int64(i)
         }
         return proto
@@ -79,26 +63,6 @@ public struct MapKey: MapKeyConvertible, ValueConvertible, TermConvertible, Expr
         switch self.wrapped {
         case .integer(let i): Value(.integer(i))
         case .string(let s): Value(s)
-        }
-    }
-}
-
-extension Biscuit_Format_Schema_MapEntry: Comparable {
-    static func < (lhs: Biscuit_Format_Schema_MapEntry, rhs: Biscuit_Format_Schema_MapEntry) -> Bool {
-        lhs.key < rhs.key || (lhs.key == rhs.key && lhs.value < rhs.value)
-    }
-}
-
-extension Biscuit_Format_Schema_MapKey: Comparable {
-    static func < (lhs: Biscuit_Format_Schema_MapKey, rhs: Biscuit_Format_Schema_MapKey) -> Bool {
-        switch (lhs.content, rhs.content) {
-        case (.integer(let l), .integer(let r)): return l < r
-        case (.string(let l), .string(let r)): return l < r
-        case (.none, .none): return true
-        case (.integer, .string): return true
-        case (.string, .integer): return false
-        case (.none, _): return true
-        case (_, .none): return false
         }
     }
 }

--- a/Sources/Biscuits/Datalog/OpBinary.swift
+++ b/Sources/Biscuits/Datalog/OpBinary.swift
@@ -20,7 +20,7 @@ enum OpBinary: Sendable, Hashable {
     case ffi(String)
     case tryOr
 
-    init(proto: Biscuit_Format_Schema_OpBinary, interner: BlockInternmentTable) throws {
+    init(proto: Biscuit_Format_Schema_OpBinary, interner: InternmentTable) throws {
         guard proto.hasKind else {
             throw Biscuit.ValidationError.missingOp
         }
@@ -84,7 +84,7 @@ enum OpBinary: Sendable, Hashable {
         }
     }
 
-    func proto(_ interner: BlockInternmentTable) -> Biscuit_Format_Schema_OpBinary {
+    func intern(_ interner: inout InternmentTable, _ locals: inout [String]) -> Biscuit_Format_Schema_OpBinary {
         var proto = Biscuit_Format_Schema_OpBinary()
         switch self {
         case .lt: proto.kind = .lessThan
@@ -115,8 +115,8 @@ enum OpBinary: Sendable, Hashable {
         case .any: proto.kind = .any
         case .all: proto.kind = .all
         case .get: proto.kind = .get
-        case .ffi(let s):
-            proto.ffiName = UInt64(interner.symbolIndex(for: s))
+        case .ffi(let name):
+            proto.ffiName = UInt64(interner.intern(name, &locals))
             proto.kind = .ffi
         case .tryOr: proto.kind = .tryOr
         }

--- a/Sources/Biscuits/Datalog/OpUnary.swift
+++ b/Sources/Biscuits/Datalog/OpUnary.swift
@@ -6,7 +6,7 @@ enum OpUnary: Sendable, Hashable {
     case negate, parens, length, typeOf
     case ffi(String)
 
-    init(proto: Biscuit_Format_Schema_OpUnary, interner: BlockInternmentTable) throws {
+    init(proto: Biscuit_Format_Schema_OpUnary, interner: InternmentTable) throws {
         guard proto.hasKind else {
             throw Biscuit.ValidationError.missingOp
         }
@@ -23,15 +23,15 @@ enum OpUnary: Sendable, Hashable {
         }
     }
 
-    func proto(_ interner: BlockInternmentTable) -> Biscuit_Format_Schema_OpUnary {
+    func intern(_ interner: inout InternmentTable, _ locals: inout [String]) -> Biscuit_Format_Schema_OpUnary {
         var proto = Biscuit_Format_Schema_OpUnary()
         switch self {
         case .negate: proto.kind = .negate
         case .parens: proto.kind = .parens
         case .length: proto.kind = .length
         case .typeOf: proto.kind = .typeOf
-        case .ffi(let s):
-            proto.ffiName = UInt64(interner.symbolIndex(for: s))
+        case .ffi(let name):
+            proto.ffiName = UInt64(interner.intern(name, &locals))
             proto.kind = .ffi
         }
         return proto

--- a/Sources/Biscuits/Datalog/Parser/Parser.swift
+++ b/Sources/Biscuits/Datalog/Parser/Parser.swift
@@ -5,8 +5,6 @@
 struct Parser {
     var lexer: Lexer
     var currentToken: Token?
-    var symbols: [String] = []
-    var publicKeys: [Biscuit.ThirdPartyKey] = []
     var origins: [TrustedScope] = []
     var policies: [Policy] = []
     var checks: [Check] = []

--- a/Sources/Biscuits/Datalog/Predicate.swift
+++ b/Sources/Biscuits/Datalog/Predicate.swift
@@ -33,7 +33,7 @@ public struct Predicate: Sendable, Hashable, CustomStringConvertible {
         self.terms = terms
     }
 
-    init(proto: Biscuit_Format_Schema_Predicate, interner: BlockInternmentTable) throws {
+    init(proto: Biscuit_Format_Schema_Predicate, interner: InternmentTable) throws {
         guard proto.hasName else {
             throw Biscuit.ValidationError.missingPredicate
         }
@@ -41,17 +41,10 @@ public struct Predicate: Sendable, Hashable, CustomStringConvertible {
         self.terms = try proto.terms.map { try Term(proto: $0, interner: interner) }
     }
 
-    func intern(_ interner: inout BlockInternmentTable, _ locals: inout [String]) {
-        interner.intern(self.name, &locals)
-        for term in self.terms {
-            term.intern(&interner, &locals)
-        }
-    }
-
-    func proto(_ interner: BlockInternmentTable) -> Biscuit_Format_Schema_Predicate {
+    func intern(_ interner: inout InternmentTable, _ locals: inout [String]) -> Biscuit_Format_Schema_Predicate {
         var proto = Biscuit_Format_Schema_Predicate()
-        proto.name = UInt64(interner.symbolIndex(for: self.name))
-        proto.terms = self.terms.map { $0.proto(interner) }
+        proto.name = UInt64(interner.intern(self.name, &locals))
+        proto.terms = self.terms.map { $0.intern(&interner, &locals) }
         return proto
     }
 

--- a/Sources/Biscuits/Datalog/Query.swift
+++ b/Sources/Biscuits/Datalog/Query.swift
@@ -12,7 +12,7 @@ extension Biscuit {
         /// The trusted scopes of this query
         public let trusted: [TrustedScope]
 
-        init(proto: Biscuit_Format_Schema_Rule, interner: BlockInternmentTable) throws {
+        init(proto: Biscuit_Format_Schema_Rule, interner: InternmentTable) throws {
             guard proto.head == Predicate.query else {
                 throw ValidationError.invalidQueryHead
             }
@@ -28,27 +28,15 @@ extension Biscuit {
         }
 
         func intern(
-            _ interner: inout BlockInternmentTable,
+            _ interner: inout InternmentTable,
             _ symbols: inout [String],
             _ publicKeys: inout [Biscuit.ThirdPartyKey]
-        ) {
-            for fact in self.predicates {
-                fact.intern(&interner, &symbols)
-            }
-            for expression in self.expressions {
-                expression.intern(&interner, &symbols)
-            }
-            for scope in self.trusted {
-                scope.intern(&interner, &publicKeys)
-            }
-        }
-
-        func proto(_ interner: BlockInternmentTable) -> Biscuit_Format_Schema_Rule {
+        ) -> Biscuit_Format_Schema_Rule {
             var proto = Biscuit_Format_Schema_Rule()
             proto.head = Predicate.query
-            proto.body = self.predicates.map { $0.proto(interner) }
-            proto.expressions = self.expressions.map { $0.proto(interner) }
-            proto.scope = self.trusted.map { $0.proto(interner) }
+            proto.body = self.predicates.map { $0.intern(&interner, &symbols) }
+            proto.expressions = self.expressions.map { $0.intern(&interner, &symbols) }
+            proto.scope = self.trusted.map { $0.intern(&interner, &publicKeys) }
             return proto
         }
 

--- a/Sources/Biscuits/Datalog/Rule.swift
+++ b/Sources/Biscuits/Datalog/Rule.swift
@@ -49,7 +49,7 @@ public struct Rule: Sendable, Hashable, CustomStringConvertible {
         self = parser.rules[0]
     }
 
-    init(proto: Biscuit_Format_Schema_Rule, interner: BlockInternmentTable) throws {
+    init(proto: Biscuit_Format_Schema_Rule, interner: InternmentTable) throws {
         guard proto.hasHead else {
             throw Biscuit.ValidationError.missingRuleHead
         }
@@ -72,28 +72,15 @@ public struct Rule: Sendable, Hashable, CustomStringConvertible {
     }
 
     func intern(
-        _ interner: inout BlockInternmentTable,
+        _ interner: inout InternmentTable,
         _ symbols: inout [String],
         _ publicKeys: inout [Biscuit.ThirdPartyKey]
-    ) {
-        self.head.intern(&interner, &symbols)
-        for fact in self.bodyPredicates {
-            fact.intern(&interner, &symbols)
-        }
-        for expression in self.expressions {
-            expression.intern(&interner, &symbols)
-        }
-        for scope in self.trusted {
-            scope.intern(&interner, &publicKeys)
-        }
-    }
-
-    func proto(_ interner: BlockInternmentTable) -> Biscuit_Format_Schema_Rule {
+    ) -> Biscuit_Format_Schema_Rule {
         var proto = Biscuit_Format_Schema_Rule()
-        proto.head = self.head.proto(interner)
-        proto.body = self.bodyPredicates.map { $0.proto(interner) }
-        proto.expressions = self.expressions.map { $0.proto(interner) }
-        proto.scope = self.trusted.map { $0.proto(interner) }
+        proto.head = self.head.intern(&interner, &symbols)
+        proto.body = self.bodyPredicates.map { $0.intern(&interner, &symbols) }
+        proto.expressions = self.expressions.map { $0.intern(&interner, &symbols) }
+        proto.scope = self.trusted.map { $0.intern(&interner, &publicKeys) }
         return proto
     }
 

--- a/Sources/Biscuits/Datalog/Term.swift
+++ b/Sources/Biscuits/Datalog/Term.swift
@@ -28,7 +28,7 @@ public struct Term: TermConvertible, ExpressionConvertible, Sendable, Hashable, 
         self.wrapped = .value(value.value)
     }
 
-    init(proto: Biscuit_Format_Schema_Term, interner: BlockInternmentTable) throws {
+    init(proto: Biscuit_Format_Schema_Term, interner: InternmentTable) throws {
         self.wrapped =
             switch proto.content {
             case .variable(let v): try .variable(interner.lookupSymbol(Int(v)))
@@ -36,11 +36,13 @@ public struct Term: TermConvertible, ExpressionConvertible, Sendable, Hashable, 
             }
     }
 
-    func intern(_ interner: inout BlockInternmentTable, _ locals: inout [String]) {
+    func intern(_ interner: inout InternmentTable, _ locals: inout [String]) -> Biscuit_Format_Schema_Term {
+        var proto = Biscuit_Format_Schema_Term()
         switch self.wrapped {
-        case .variable(let name): interner.intern(name, &locals)
-        case .value(let term): term.intern(&interner, &locals)
+        case .variable(let name): proto.variable = UInt32(interner.intern(name, &locals))
+        case .value(let term): return term.intern(&interner, &locals)
         }
+        return proto
     }
 
     func makeConcrete(variables: [String: Value]) throws -> Value {
@@ -52,15 +54,6 @@ public struct Term: TermConvertible, ExpressionConvertible, Sendable, Hashable, 
             return term
         case .value(let term): return term
         }
-    }
-
-    func proto(_ interner: BlockInternmentTable) -> Biscuit_Format_Schema_Term {
-        var proto = Biscuit_Format_Schema_Term()
-        switch self.wrapped {
-        case .variable(let v): proto.variable = UInt32(interner.symbolIndex(for: v))
-        case .value(let term): return term.proto(interner)
-        }
-        return proto
     }
 
     var isConcrete: Bool {

--- a/Sources/Biscuits/Datalog/TrustedScope.swift
+++ b/Sources/Biscuits/Datalog/TrustedScope.swift
@@ -30,7 +30,7 @@ public struct TrustedScope: Equatable, Sendable, Hashable, CustomStringConvertib
         self.wrapped = try .publicKey(Biscuit.ThirdPartyKey(algorithm: algorithm, hexString: hexString))
     }
 
-    init(proto: Biscuit_Format_Schema_Scope, interner: BlockInternmentTable) throws {
+    init(proto: Biscuit_Format_Schema_Scope, interner: InternmentTable) throws {
         self.wrapped =
             switch proto.content {
             case .scopeType(.authority): .authority
@@ -44,18 +44,18 @@ public struct TrustedScope: Equatable, Sendable, Hashable, CustomStringConvertib
         TrustedScope(.publicKey(Biscuit.ThirdPartyKey(key: key)))
     }
 
-    func intern(_ interner: inout BlockInternmentTable, _ keys: inout [Biscuit.ThirdPartyKey]) {
-        if case .publicKey(let key) = self.wrapped {
-            interner.intern(key, &keys)
-        }
-    }
-
-    func proto(_ interner: BlockInternmentTable) -> Biscuit_Format_Schema_Scope {
+    func intern(
+        _ interner: inout InternmentTable,
+        _ keys: inout [Biscuit.ThirdPartyKey]
+    )
+        -> Biscuit_Format_Schema_Scope
+    {
         var proto = Biscuit_Format_Schema_Scope()
         switch self.wrapped {
         case .authority: proto.scopeType = .authority
         case .previous: proto.scopeType = .previous
-        case .publicKey(let key): proto.publicKey = Int64(interner.publicKeyIndex(for: key))
+        case .publicKey(let key):
+            proto.publicKey = Int64(interner.intern(key, &keys))
         }
         return proto
     }

--- a/Sources/Biscuits/Datalog/Value.swift
+++ b/Sources/Biscuits/Datalog/Value.swift
@@ -181,7 +181,7 @@ public struct Value: ValueConvertible, TermConvertible, ExpressionConvertible, S
         self.wrapped = wrapped
     }
 
-    init(proto: Biscuit_Format_Schema_Term, interner: BlockInternmentTable) throws {
+    init(proto: Biscuit_Format_Schema_Term, interner: InternmentTable) throws {
         self.wrapped =
             switch proto.content {
             case .integer(let i): .integer(i)
@@ -220,45 +220,6 @@ public struct Value: ValueConvertible, TermConvertible, ExpressionConvertible, S
             case .variable: throw Biscuit.ValidationError.variableInFact
             case .none: throw Biscuit.ValidationError.missingTerm
             }
-    }
-
-    // Intentionally not public and Value does not conform to Comparable
-    static func < (lhs: Value, rhs: Value) -> Bool {
-        switch (lhs.wrapped, rhs.wrapped) {
-        case (.integer(let l), .integer(let r)): return l < r
-        case (.string(let l), .string(let r)): return l < r
-        case (.date(let l), .date(let r)): return l < r
-        case (.bytes(let l), .bytes(let r)):
-            guard l.count <= r.count else { return false }
-            return zip(l, r).allSatisfy { $0 < $1 }
-        case (.bool(let l), .bool(let r)): return !l && r
-        case (.set(let l), .set(let r)):
-            guard l.count <= r.count else { return false }
-            return zip(l.sorted(by: <), r.sorted(by: <)).allSatisfy { $0 < $1 }
-        case (.null, .null): return false
-        case (.array(let l), .array(let r)):
-            guard l.count <= r.count else { return false }
-            return zip(l, r).allSatisfy { $0 < $1 }
-        case (.map(let l), .map(let r)):
-            guard l.count <= r.count else { return false }
-            return zip(l.sorted(by: { $0.0 < $1.0 }), r.sorted(by: { $0.0 < $1.0 })).allSatisfy { $0.1 < $1.1 }
-        case (.integer, _): return true
-        case (_, .integer): return false
-        case (.string, _): return true
-        case (_, .string): return false
-        case (.date, _): return true
-        case (_, .date): return false
-        case (.bytes, _): return true
-        case (_, .bytes): return false
-        case (.bool, _): return true
-        case (_, .bool): return false
-        case (.set, _): return true
-        case (_, .set): return false
-        case (.null, _): return true
-        case (_, .null): return false
-        case (.array, _): return true
-        case (_, .array): return false
-        }
     }
 
     /// A negation expression
@@ -421,49 +382,29 @@ public struct Value: ValueConvertible, TermConvertible, ExpressionConvertible, S
         self.expression.tryOr(rhs)
     }
 
-    func intern(_ interner: inout BlockInternmentTable, _ locals: inout [String]) {
-        switch self.wrapped {
-        case .string(let string):
-            interner.intern(string, &locals)
-        case .set(let set):
-            for term in set.sorted(by: <) {
-                term.intern(&interner, &locals)
-            }
-        case .array(let array):
-            for term in array {
-                term.intern(&interner, &locals)
-            }
-        case .map(let map):
-            for (key, val) in map.sorted(by: { $0.0 < $1.0 }) {
-                key.intern(&interner, &locals)
-                val.intern(&interner, &locals)
-            }
-        default: return
-        }
-    }
-
-    func proto(_ interner: BlockInternmentTable) -> Biscuit_Format_Schema_Term {
+    func intern(_ interner: inout InternmentTable, _ locals: inout [String]) -> Biscuit_Format_Schema_Term {
         var proto = Biscuit_Format_Schema_Term()
         switch self.wrapped {
         case .integer(let i): proto.integer = Int64(i)
-        case .string(let s): proto.string = UInt64(interner.symbolIndex(for: s))
+        case .string(let string):
+            proto.string = UInt64(interner.intern(string, &locals))
         case .date(let d): proto.date = UInt64(d.timeIntervalSince1970)
         case .bytes(let b): proto.bytes = b
         case .bool(let b): proto.bool = b
-        case .set(let terms):
+        case .set(let set):
             proto.set = Biscuit_Format_Schema_TermSet()
-            proto.set.set = terms.map { $0.proto(interner) }.sorted(by: <)
-        case .array(let terms):
+            proto.set.set = set.map { $0.intern(&interner, &locals) }
+        case .array(let array):
             proto.array = Biscuit_Format_Schema_Array()
-            proto.array.array = terms.map { $0.proto(interner) }
-        case .map(let terms):
+            proto.array.array = array.map { $0.intern(&interner, &locals) }
+        case .map(let map):
             proto.map = Biscuit_Format_Schema_Map()
-            proto.map.entries = terms.map {
+            for (key, val) in map {
                 var entry = Biscuit_Format_Schema_MapEntry()
-                entry.key = $0.proto(interner)
-                entry.value = $1.proto(interner)
-                return entry
-            }.sorted(by: <)
+                entry.key = key.intern(&interner, &locals)
+                entry.value = val.intern(&interner, &locals)
+                proto.map.entries.append(entry)
+            }
         case .null: proto.null = Biscuit_Format_Schema_Empty()
         }
         return proto
@@ -478,9 +419,9 @@ public struct Value: ValueConvertible, TermConvertible, ExpressionConvertible, S
         case .date(let date): "\(date)"
         case .bytes(let bytes): "hex:\(bytes.map { String(format: "%02hhx", $0) }.joined())"
         case .bool(let bool): "\(bool)"
-        case .set(let set): set.isEmpty ? "{,}" : "{\(set.sorted(by: <).map { "\($0)" }.joined(separator: ", "))}"
+        case .set(let set): set.isEmpty ? "{,}" : "{\(set.map { "\($0)" }.joined(separator: ", "))}"
         case .array(let array): "[\(array.map { "\($0)" }.joined(separator: ", "))]"
-        case .map(let dict): "{\(dict.sorted(by: { $0.0 < $1.0 }).map { "\($0): \($1)" }.joined(separator: ", "))}"
+        case .map(let dict): "{\(dict.map { "\($0): \($1)" }.joined(separator: ", "))}"
         case .null: "null"
         }
     }
@@ -746,51 +687,6 @@ public struct Value: ValueConvertible, TermConvertible, ExpressionConvertible, S
             throw Biscuit.EvaluationError.typeError
         }
         return value
-    }
-}
-
-extension Biscuit_Format_Schema_Term: Comparable {
-    static func < (lhs: Biscuit_Format_Schema_Term, rhs: Biscuit_Format_Schema_Term) -> Bool {
-        switch (lhs.content, rhs.content) {
-        case (.variable(let l), .variable(let r)): return l < r
-        case (.integer(let l), .integer(let r)): return l < r
-        case (.string(let l), .string(let r)): return l < r
-        case (.date(let l), .date(let r)): return l < r
-        case (.bytes(let l), .bytes(let r)):
-            guard l.count <= r.count else { return false }
-            return zip(l, r).allSatisfy { $0 < $1 }
-        case (.bool(let l), .bool(let r)): return !l && r
-        case (.set(let l), .set(let r)):
-            guard l.set.count <= r.set.count else { return false }
-            return zip(l.set.sorted(), r.set.sorted()).allSatisfy { $0 < $1 }
-        case (.null, .null): return false
-        case (.array(let l), .array(let r)):
-            guard l.array.count <= r.array.count else { return false }
-            return zip(l.array, r.array).allSatisfy { $0 < $1 }
-        case (.map(let l), .map(let r)):
-            guard l.entries.count <= r.entries.count else { return false }
-            return zip(l.entries.sorted(), r.entries.sorted()).allSatisfy { $0 < $1 }
-        case (.none, _): return true
-        case (_, .none): return false
-        case (.variable, _): return true
-        case (_, .variable): return false
-        case (.integer, _): return true
-        case (_, .integer): return false
-        case (.string, _): return true
-        case (_, .string): return false
-        case (.date, _): return true
-        case (_, .date): return false
-        case (.bytes, _): return true
-        case (_, .bytes): return false
-        case (.bool, _): return true
-        case (_, .bool): return false
-        case (.set, _): return true
-        case (_, .set): return false
-        case (.null, _): return true
-        case (_, .null): return false
-        case (.array, _): return true
-        case (_, .array): return false
-        }
     }
 }
 

--- a/Sources/Biscuits/Proof.swift
+++ b/Sources/Biscuits/Proof.swift
@@ -24,10 +24,10 @@ extension Biscuit {
             }
         }
 
-        func isValidProof(for block: Block, interner: BlockInternmentTable) throws {
+        func isValidProof(for block: Block) throws {
             switch self {
             case .finalSignature(let sig):
-                try block.nextKey.isValidSealingSignature(sig, for: block, interner: interner)
+                try block.nextKey.isValidSealingSignature(sig, for: block)
             case .nextSecret(let nextKey):
                 guard block.nextKey == nextKey.publicKey else {
                     throw ValidationError.invalidProof

--- a/Sources/Biscuits/ThirdPartyBlockRequest.swift
+++ b/Sources/Biscuits/ThirdPartyBlockRequest.swift
@@ -11,7 +11,7 @@ import Foundation
 extension Biscuit {
     /// Generates a request for a third party to attenuate this token
     public func generateThirdPartyBlockRequest() -> ThirdPartyBlockRequest {
-        ThirdPartyBlockRequest(previousSignature: self.lastSig)
+        ThirdPartyBlockRequest(previousSignature: self.lastBlock.signature)
     }
 
     /// Attenuate a token with a `ThirdPartyBlockContents`
@@ -31,11 +31,11 @@ extension Biscuit {
             contents: contents,
             nextKey: nextKey.publicKey,
             lastKey: lastKey,
-            lastSig: self.lastSig
+            lastSig: self.lastBlock.signature
         )
         try contents.externalSignature.isValidSignature(
             for: attenuation,
-            lastSig: self.lastSig,
+            lastSig: self.lastBlock.signature,
         )
         let attenuations = self.attenuations + [attenuation]
         return Biscuit(self, attenuations, self.interner, .nextSecret(nextKey))

--- a/Sources/Biscuits/ThirdPartyBlockRequest.swift
+++ b/Sources/Biscuits/ThirdPartyBlockRequest.swift
@@ -11,8 +11,7 @@ import Foundation
 extension Biscuit {
     /// Generates a request for a third party to attenuate this token
     public func generateThirdPartyBlockRequest() -> ThirdPartyBlockRequest {
-        let lastSig = self.attenuations.last?.signature ?? self.authority.signature
-        return ThirdPartyBlockRequest(previousSignature: lastSig)
+        ThirdPartyBlockRequest(previousSignature: self.lastSig)
     }
 
     /// Attenuate a token with a `ThirdPartyBlockContents`
@@ -28,24 +27,18 @@ extension Biscuit {
             throw AttenuationError.cannotAttenuateSealedToken
         }
         let nextKey = InternalPrivateKey(algorithm: algorithm)
-        let lastSig = self.attenuations.last?.signature ?? self.authority.signature
         let attenuation = try Block(
-            datalog: contents.payload,
+            contents: contents,
             nextKey: nextKey.publicKey,
             lastKey: lastKey,
-            lastSig: lastSig,
-            externalSignature: contents.externalSignature,
-            interner: contents.interner
+            lastSig: self.lastSig
         )
         try contents.externalSignature.isValidSignature(
             for: attenuation,
-            lastSig: lastSig,
-            interner: contents.interner
+            lastSig: self.lastSig,
         )
         let attenuations = self.attenuations + [attenuation]
-        var interner = self.interner
-        interner.setBlockTable(contents.interner, for: attenuations.count)
-        return Biscuit(self, attenuations, interner, .nextSecret(nextKey))
+        return Biscuit(self, attenuations, self.interner, .nextSecret(nextKey))
     }
 
     /// A request for a third party to attenuate this token
@@ -80,7 +73,7 @@ extension Biscuit {
             context: String? = nil,
             @DatalogBlock using datalog: () throws -> DatalogBlock
         ) throws -> ThirdPartyBlockContents {
-            try ThirdPartyBlockContents(using: datalog(), privateKey, context, self)
+            try ThirdPartyBlockContents(using: DatalogBlock(context: context, datalog), privateKey, self)
         }
 
         /// Generates a block that can be used to attenuate a Biscuit.
@@ -95,15 +88,14 @@ extension Biscuit {
             privateKey: Key,
             context: String? = nil
         ) throws -> ThirdPartyBlockContents {
-            try ThirdPartyBlockContents(using: DatalogBlock(datalog), privateKey, context, self)
+            try ThirdPartyBlockContents(using: DatalogBlock(datalog, context: context), privateKey, self)
         }
 
         public func generateBlock<Key: PrivateKey>(
             using datalog: DatalogBlock,
             privateKey: Key,
-            context: String? = nil
         ) throws -> ThirdPartyBlockContents {
-            try ThirdPartyBlockContents(using: datalog, privateKey, context, self)
+            try ThirdPartyBlockContents(using: datalog, privateKey, self)
         }
 
         /// Serializes this ThirdPartyBlockRequest to its data representation
@@ -123,8 +115,8 @@ extension Biscuit {
     /// The contents of a block signed by a third party with a `ThirdPartyBlockRequest`
     public struct ThirdPartyBlockContents: Sendable, Hashable {
         var payload: DatalogBlock
+        var serializedPayload: Data
         var externalSignature: Block.ExternalSignature
-        var interner: BlockInternmentTable
 
         /// Deserializes a ThirdPartyBlockContents from its data representation.
         /// - Throws: May throw an error during deserialization
@@ -136,25 +128,24 @@ extension Biscuit {
             guard proto.hasExternalSignature else {
                 throw ValidationError.missingExternalSignature
             }
-            self.interner = BlockInternmentTable()
-            self.payload = try DatalogBlock(serializedData: proto.payload, &self.interner)
+            var interner = InternmentTable()
+            self.payload = try DatalogBlock(serializedData: proto.payload, &interner)
+            self.serializedPayload = proto.payload
             self.externalSignature = try Block.ExternalSignature(proto: proto.externalSignature)
         }
 
         init<Key: PrivateKey>(
             using datalog: DatalogBlock,
             _ key: Key,
-            _ context: String?,
             _ request: ThirdPartyBlockRequest
         ) throws {
-            self.interner = BlockInternmentTable()
+            var interner = InternmentTable()
             self.payload = datalog
-            self.payload.attachToBiscuit(interner: &self.interner, context: context)
+            self.serializedPayload = try datalog.serializeInBiscuit(interner: &interner)
             self.externalSignature = try Block.ExternalSignature(
-                block: self.payload,
+                block: self.serializedPayload,
                 lastSig: request.previousSignature,
                 thirdPartyKey: key,
-                interner: self.interner
             )
         }
 
@@ -162,12 +153,12 @@ extension Biscuit {
         /// Returns: the data representation of this ThirdPartyBlockContents
         /// Throws: May throw a serialization error
         public func serializedData() throws -> Data {
-            try self.proto().serializedData()
+            try self.proto.serializedData()
         }
 
-        func proto() throws -> Biscuit_Format_Schema_ThirdPartyBlockContents {
+        var proto: Biscuit_Format_Schema_ThirdPartyBlockContents {
             var proto = Biscuit_Format_Schema_ThirdPartyBlockContents()
-            proto.payload = try self.payload.serializedData(self.interner)
+            proto.payload = self.serializedPayload
             proto.externalSignature = self.externalSignature.proto
             return proto
         }

--- a/Sources/Biscuits/UnverifiedBiscuit.swift
+++ b/Sources/Biscuits/UnverifiedBiscuit.swift
@@ -39,12 +39,13 @@ public struct UnverifiedBiscuit: Sendable, Hashable {
         }
         var interner = InternmentTable()
         self.authority = try Biscuit.Block.unverifiedAuthority(proto: proto.authority, interner: &interner)
+        var lastBlock = self.authority
         self.attenuations = try proto.blocks.map {
-            try Biscuit.Block.unverifiedAttenuation(proto: $0, interner: &interner)
+            lastBlock = try Biscuit.Block.unverifiedAttenuation(proto: $0, interner: &interner)
+            return lastBlock
         }
-        let algorithm = self.attenuations.last?.nextKey.algorithm ?? self.authority.nextKey.algorithm
-        self.proof = try Biscuit.Proof(proto: proto.proof, algorithm: algorithm)
         self.interner = interner
+        self.proof = try Biscuit.Proof(proto: proto.proof, algorithm: lastBlock.nextKey.algorithm)
     }
 
     /// Deserializes an UnverifiedBiscuit from its base64url representation without
@@ -105,6 +106,7 @@ public struct UnverifiedBiscuit: Sendable, Hashable {
             }
             lastBlock = block
         }
+        try self.proof.isValidProof(for: lastBlock)
         return Biscuit(unverifiedBiscuit: self)
     }
 
@@ -220,7 +222,7 @@ public struct UnverifiedBiscuit: Sendable, Hashable {
                 datalog: datalog,
                 nextKey: nextKey.publicKey,
                 lastKey: lastKey,
-                lastSig: self.lastSig,
+                lastSig: self.lastBlock.signature,
                 interner: &interner
             )
         )
@@ -253,7 +255,7 @@ public struct UnverifiedBiscuit: Sendable, Hashable {
                 datalog: datalog,
                 nextKey: nextKey.publicKey,
                 lastKey: lastKey,
-                lastSig: self.lastSig,
+                lastSig: self.lastBlock.signature,
                 thirdPartyKey: thirdPartyKey,
             )
         )
@@ -267,7 +269,7 @@ public struct UnverifiedBiscuit: Sendable, Hashable {
     /// - Throws: Signing may throw an error
     public func sealed() throws -> UnverifiedBiscuit {
         if case .nextSecret(let key) = self.proof {
-            let sig = try key.sealingSignature(for: self.attenuations.last ?? self.authority)
+            let sig = try key.sealingSignature(for: self.lastBlock)
             return UnverifiedBiscuit(self, self.attenuations, self.interner, .finalSignature(sig))
         } else {
             return self
@@ -306,7 +308,7 @@ public struct UnverifiedBiscuit: Sendable, Hashable {
 
     /// Generates a request for a third party to attenuate this token
     public func generateThirdPartyBlockRequest() -> Biscuit.ThirdPartyBlockRequest {
-        Biscuit.ThirdPartyBlockRequest(previousSignature: self.lastSig)
+        Biscuit.ThirdPartyBlockRequest(previousSignature: self.lastBlock.signature)
     }
 
     /// Attenuate a token with a `ThirdPartyBlockContents`
@@ -326,11 +328,11 @@ public struct UnverifiedBiscuit: Sendable, Hashable {
             contents: contents,
             nextKey: nextKey.publicKey,
             lastKey: lastKey,
-            lastSig: self.lastSig
+            lastSig: self.lastBlock.signature
         )
         try contents.externalSignature.isValidSignature(
             for: attenuation,
-            lastSig: lastSig,
+            lastSig: self.lastBlock.signature,
         )
         let attenuations = self.attenuations + [attenuation]
         return UnverifiedBiscuit(self, attenuations, self.interner, .nextSecret(nextKey))
@@ -339,7 +341,7 @@ public struct UnverifiedBiscuit: Sendable, Hashable {
     /// Whether or not this UnverifiedBiscuit has been sealed
     public var isSealed: Bool { self.proof.isSealed }
 
-    var lastSig: Data {
-        self.attenuations.last?.signature ?? self.authority.signature
+    var lastBlock: Biscuit.Block {
+        self.attenuations.last ?? self.authority
     }
 }

--- a/Sources/Biscuits/UnverifiedBiscuit.swift
+++ b/Sources/Biscuits/UnverifiedBiscuit.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// An UnverifiedBiscuit is a biscuit which has not been cryptographically verified.
 public struct UnverifiedBiscuit: Sendable, Hashable {
-    let interner: InternmentTables
+    let interner: InternmentTable
     let proof: Biscuit.Proof
 
     /// The ID of the key used to sign the authority block of this Biscuit, if one is specified
@@ -37,14 +37,13 @@ public struct UnverifiedBiscuit: Sendable, Hashable {
         } else {
             self.rootKeyID = nil
         }
-        var interner = InternmentTables()
-        self.authority = try Biscuit.Block(proto: proto.authority, interner: &interner)
-        var lastBlock = self.authority
-        self.attenuations = try proto.blocks.enumerated().map {
-            lastBlock = try Biscuit.Block(proto: $1, blockID: $0 + 1, interner: &interner)
-            return lastBlock
+        var interner = InternmentTable()
+        self.authority = try Biscuit.Block.unverifiedAuthority(proto: proto.authority, interner: &interner)
+        self.attenuations = try proto.blocks.map {
+            try Biscuit.Block.unverifiedAttenuation(proto: $0, interner: &interner)
         }
-        self.proof = try Biscuit.Proof(proto: proto.proof, algorithm: lastBlock.nextKey.algorithm)
+        let algorithm = self.attenuations.last?.nextKey.algorithm ?? self.authority.nextKey.algorithm
+        self.proof = try Biscuit.Proof(proto: proto.proof, algorithm: algorithm)
         self.interner = interner
     }
 
@@ -72,7 +71,7 @@ public struct UnverifiedBiscuit: Sendable, Hashable {
     init(
         _ parent: UnverifiedBiscuit,
         _ attenuations: [Biscuit.Block],
-        _ interner: InternmentTables,
+        _ interner: InternmentTable,
         _ proof: Biscuit.Proof
     ) {
         self.interner = interner
@@ -88,14 +87,13 @@ public struct UnverifiedBiscuit: Sendable, Hashable {
     /// - Parameters using: the key used to verify this biscuit
     /// - Throw: A ValidationError is thrown if any signature is invalid
     public func verify<Key: Biscuit.PublicKey>(using key: Key) throws -> Biscuit {
-        let signatureInput = try self.authority.signatureInput(interner: interner.primary)
+        let signatureInput = self.authority.signatureInput()
         guard key.isValidSignature(self.authority.signature, for: signatureInput) else {
             throw Biscuit.ValidationError.invalidSignature
         }
         var lastBlock = self.authority
-        for (blockID, block) in self.attenuations.enumerated() {
-            let blockInterner = interner.blockTable(for: blockID + 1)
-            let signatureInput = try block.signatureInput(interner: blockInterner, lastSig: lastBlock.signature)
+        for block in self.attenuations {
+            let signatureInput = block.signatureInput(lastSig: lastBlock.signature)
             guard lastBlock.nextKey.isValidSignature(block.signature, for: signatureInput) else {
                 throw Biscuit.ValidationError.invalidSignature
             }
@@ -103,7 +101,6 @@ public struct UnverifiedBiscuit: Sendable, Hashable {
                 try externalSignature.isValidSignature(
                     for: block,
                     lastSig: lastBlock.signature,
-                    interner: blockInterner
                 )
             }
             lastBlock = block
@@ -126,7 +123,7 @@ public struct UnverifiedBiscuit: Sendable, Hashable {
         context: String? = nil,
         @Biscuit.DatalogBlock using datalog: () throws -> Biscuit.DatalogBlock
     ) throws -> UnverifiedBiscuit {
-        try self.attenuated(using: datalog(), algorithm: algorithm, context: context)
+        try self.attenuated(using: Biscuit.DatalogBlock(context: context, datalog), algorithm: algorithm)
     }
 
     /// Attenuate this Biscuit, producing a new Biscuit which has been attenuated to a smaller
@@ -147,10 +144,9 @@ public struct UnverifiedBiscuit: Sendable, Hashable {
         @Biscuit.DatalogBlock using datalog: () throws -> Biscuit.DatalogBlock
     ) throws -> UnverifiedBiscuit {
         try self.attenuated(
-            using: datalog(),
+            using: Biscuit.DatalogBlock(context: context, datalog),
             thirdPartyKey: thirdPartyKey,
             algorithm: algorithm,
-            context: context
         )
     }
 
@@ -170,9 +166,8 @@ public struct UnverifiedBiscuit: Sendable, Hashable {
         context: String? = nil
     ) throws -> UnverifiedBiscuit {
         try self.attenuated(
-            using: Biscuit.DatalogBlock(datalog),
+            using: Biscuit.DatalogBlock(datalog, context: context),
             algorithm: algorithm,
-            context: context
         )
     }
 
@@ -194,10 +189,9 @@ public struct UnverifiedBiscuit: Sendable, Hashable {
         context: String? = nil
     ) throws -> UnverifiedBiscuit {
         try self.attenuated(
-            using: Biscuit.DatalogBlock(datalog),
+            using: Biscuit.DatalogBlock(datalog, context: context),
             thirdPartyKey: thirdPartyKey,
             algorithm: algorithm,
-            context: context
         )
     }
 
@@ -214,25 +208,20 @@ public struct UnverifiedBiscuit: Sendable, Hashable {
     public func attenuated(
         using datalog: Biscuit.DatalogBlock,
         algorithm: Biscuit.SigningAlgorithm = .ed25519,
-        context: String? = nil
     ) throws -> UnverifiedBiscuit {
         guard case .nextSecret(let lastKey) = self.proof else {
             throw Biscuit.AttenuationError.cannotAttenuateSealedToken
         }
         var interner = self.interner
-        var attenuation = datalog
-        attenuation.attachToBiscuit(interner: &interner.primary, context: context)
         let nextKey = Biscuit.InternalPrivateKey(algorithm: algorithm)
-        let lastSig = self.attenuations.last?.signature ?? self.authority.signature
         var attenuations = self.attenuations
         try attenuations.append(
             Biscuit.Block(
-                datalog: attenuation,
+                datalog: datalog,
                 nextKey: nextKey.publicKey,
                 lastKey: lastKey,
-                lastSig: lastSig,
-                externalSignature: nil,
-                interner: interner.primary
+                lastSig: self.lastSig,
+                interner: &interner
             )
         )
         return UnverifiedBiscuit(self, attenuations, interner, .nextSecret(nextKey))
@@ -253,36 +242,22 @@ public struct UnverifiedBiscuit: Sendable, Hashable {
         using datalog: Biscuit.DatalogBlock,
         thirdPartyKey: Key,
         algorithm: Biscuit.SigningAlgorithm = .ed25519,
-        context: String? = nil
     ) throws -> UnverifiedBiscuit {
         guard case .nextSecret(let lastKey) = self.proof else {
             throw Biscuit.AttenuationError.cannotAttenuateSealedToken
         }
-        var blockInterner = BlockInternmentTable()
-        var attenuation = datalog
-        attenuation.attachToBiscuit(interner: &blockInterner, context: context)
         let nextKey = Biscuit.InternalPrivateKey(algorithm: algorithm)
-        let lastSig = self.attenuations.last?.signature ?? self.authority.signature
         var attenuations = self.attenuations
-        let externalSignature = try Biscuit.Block.ExternalSignature(
-            block: attenuation,
-            lastSig: lastSig,
-            thirdPartyKey: thirdPartyKey,
-            interner: blockInterner
-        )
         try attenuations.append(
             Biscuit.Block(
-                datalog: attenuation,
+                datalog: datalog,
                 nextKey: nextKey.publicKey,
                 lastKey: lastKey,
-                lastSig: lastSig,
-                externalSignature: externalSignature,
-                interner: blockInterner
+                lastSig: self.lastSig,
+                thirdPartyKey: thirdPartyKey,
             )
         )
-        var interner = self.interner
-        interner.setBlockTable(blockInterner, for: attenuations.count)
-        return UnverifiedBiscuit(self, attenuations, interner, .nextSecret(nextKey))
+        return UnverifiedBiscuit(self, attenuations, self.interner, .nextSecret(nextKey))
     }
 
     /// Seal this Biscuit, producing a new Biscuit which cannot be attenuated further. This Biscuit
@@ -292,10 +267,7 @@ public struct UnverifiedBiscuit: Sendable, Hashable {
     /// - Throws: Signing may throw an error
     public func sealed() throws -> UnverifiedBiscuit {
         if case .nextSecret(let key) = self.proof {
-            let sig = try key.sealingSignature(
-                for: self.attenuations.last ?? self.authority,
-                interner: self.interner.blockTable(for: self.attenuations.count)
-            )
+            let sig = try key.sealingSignature(for: self.attenuations.last ?? self.authority)
             return UnverifiedBiscuit(self, self.attenuations, self.interner, .finalSignature(sig))
         } else {
             return self
@@ -306,14 +278,14 @@ public struct UnverifiedBiscuit: Sendable, Hashable {
     /// - Returns: the data representation of this Biscuit
     /// - Throws: May throw an error if protobuf serialization fails
     public func serializedData() throws -> Data {
-        try self.proto().serializedData()
+        try self.proto.serializedData()
     }
 
     /// Serialize this UnverifiedBiscuit to its base64url encoded representation
     /// - Returns: the base64url encoded representation of this Biscuit
     /// - Throws: May thow an error if protobuf serialization fails
     public func base64URLEncoded() throws -> String {
-        let base64Encoded = try self.proto().serializedData().base64EncodedString()
+        let base64Encoded = try self.serializedData().base64EncodedString()
         // Translate base64 into base64url, ignoring padding, as defined in RFC4648.
         return
             base64Encoded
@@ -321,23 +293,20 @@ public struct UnverifiedBiscuit: Sendable, Hashable {
             .replacingOccurrences(of: "/", with: "_")
     }
 
-    func proto() throws -> Biscuit_Format_Schema_Biscuit {
+    var proto: Biscuit_Format_Schema_Biscuit {
         var proto = Biscuit_Format_Schema_Biscuit()
         if let rootKeyID = self.rootKeyID {
             proto.rootKeyID = rootKeyID.rawValue
         }
-        proto.authority = try self.authority.proto(interner: self.interner.primary)
-        proto.blocks = try self.attenuations.enumerated().map {
-            try $1.proto(interner: self.interner.blockTable(for: $0))
-        }
+        proto.authority = self.authority.proto
+        proto.blocks = self.attenuations.map { $0.proto }
         proto.proof = self.proof.proto
         return proto
     }
 
     /// Generates a request for a third party to attenuate this token
     public func generateThirdPartyBlockRequest() -> Biscuit.ThirdPartyBlockRequest {
-        let lastSig = self.attenuations.last?.signature ?? self.authority.signature
-        return Biscuit.ThirdPartyBlockRequest(previousSignature: lastSig)
+        Biscuit.ThirdPartyBlockRequest(previousSignature: self.lastSig)
     }
 
     /// Attenuate a token with a `ThirdPartyBlockContents`
@@ -353,26 +322,24 @@ public struct UnverifiedBiscuit: Sendable, Hashable {
             throw Biscuit.AttenuationError.cannotAttenuateSealedToken
         }
         let nextKey = Biscuit.InternalPrivateKey(algorithm: algorithm)
-        let lastSig = self.attenuations.last?.signature ?? self.authority.signature
         let attenuation = try Biscuit.Block(
-            datalog: contents.payload,
+            contents: contents,
             nextKey: nextKey.publicKey,
             lastKey: lastKey,
-            lastSig: lastSig,
-            externalSignature: contents.externalSignature,
-            interner: contents.interner
+            lastSig: self.lastSig
         )
         try contents.externalSignature.isValidSignature(
             for: attenuation,
             lastSig: lastSig,
-            interner: contents.interner
         )
         let attenuations = self.attenuations + [attenuation]
-        var interner = self.interner
-        interner.setBlockTable(contents.interner, for: attenuations.count)
-        return UnverifiedBiscuit(self, attenuations, interner, .nextSecret(nextKey))
+        return UnverifiedBiscuit(self, attenuations, self.interner, .nextSecret(nextKey))
     }
 
     /// Whether or not this UnverifiedBiscuit has been sealed
     public var isSealed: Bool { self.proof.isSealed }
+
+    var lastSig: Data {
+        self.attenuations.last?.signature ?? self.authority.signature
+    }
 }

--- a/Tests/BiscuitsTests/BiscuitsTests.swift
+++ b/Tests/BiscuitsTests/BiscuitsTests.swift
@@ -9,17 +9,12 @@ import XCTest
 
 final class BiscuitsTests: XCTestCase {
     func testDatalogBlockWithFact() throws {
-        var interner = BlockInternmentTable()
-        var block = try Biscuit.DatalogBlock("foo(1234);")
-        block.attachToBiscuit(interner: &interner, context: nil)
-        XCTAssertEqual(block.version, 6)
+        let block = try Biscuit.DatalogBlock("foo(1234);")
         XCTAssertEqual(block.context, nil)
         XCTAssert(block.checks.isEmpty)
         XCTAssert(block.rules.isEmpty)
         XCTAssert(block.trusted.isEmpty)
-        XCTAssert(block.publicKeys.isEmpty)
 
-        XCTAssertEqual(block.symbols, ["foo"])
         XCTAssertEqual(block.facts.count, 1)
         let fact = block.facts[0]
         XCTAssertEqual(fact.name, "foo")
@@ -27,17 +22,12 @@ final class BiscuitsTests: XCTestCase {
     }
 
     func testDatalogBlockWithRule() throws {
-        var interner = BlockInternmentTable()
-        var block = try Biscuit.DatalogBlock("foo($bar) <- user($bar);")
-        block.attachToBiscuit(interner: &interner, context: nil)
-        XCTAssertEqual(block.version, 6)
+        let block = try Biscuit.DatalogBlock("foo($bar) <- user($bar);")
         XCTAssertEqual(block.context, nil)
         XCTAssert(block.facts.isEmpty)
         XCTAssert(block.checks.isEmpty)
         XCTAssert(block.trusted.isEmpty)
-        XCTAssert(block.publicKeys.isEmpty)
 
-        XCTAssertEqual(block.symbols, ["foo", "bar"])
         XCTAssertEqual(block.rules.count, 1)
         let rule = block.rules[0]
         XCTAssert(rule.expressions.isEmpty)
@@ -52,17 +42,12 @@ final class BiscuitsTests: XCTestCase {
     }
 
     func testDatalogBlockWithCheck() throws {
-        var interner = BlockInternmentTable()
-        var block = try Biscuit.DatalogBlock("check if foo(\"bar\", \"foo\");")
-        block.attachToBiscuit(interner: &interner, context: nil)
-        XCTAssertEqual(block.version, 6)
+        let block = try Biscuit.DatalogBlock("check if foo(\"bar\", \"foo\");")
         XCTAssertEqual(block.context, nil)
         XCTAssert(block.facts.isEmpty)
         XCTAssert(block.rules.isEmpty)
         XCTAssert(block.trusted.isEmpty)
-        XCTAssert(block.publicKeys.isEmpty)
 
-        XCTAssertEqual(block.symbols, ["foo", "bar"])
         XCTAssertEqual(block.checks.count, 1)
         let check = block.checks[0]
         XCTAssertEqual(check.kind, .checkIf)
@@ -77,16 +62,11 @@ final class BiscuitsTests: XCTestCase {
     }
 
     func testDatalogBlockWithMultipleFacts() throws {
-        var interner = BlockInternmentTable()
-        var block = try Biscuit.DatalogBlock("user(1234); admin(1234);")
-        block.attachToBiscuit(interner: &interner, context: nil)
-        XCTAssertEqual(block.version, 6)
+        let block = try Biscuit.DatalogBlock("user(1234); admin(1234);")
         XCTAssertEqual(block.context, nil)
         XCTAssert(block.checks.isEmpty)
         XCTAssert(block.rules.isEmpty)
         XCTAssert(block.trusted.isEmpty)
-        XCTAssert(block.publicKeys.isEmpty)
-        XCTAssert(block.symbols.isEmpty)
 
         XCTAssertEqual(block.facts.count, 2)
         let fact1 = block.facts[0]
@@ -98,17 +78,12 @@ final class BiscuitsTests: XCTestCase {
     }
 
     func testDatalogBlockWithExpression() throws {
-        var interner = BlockInternmentTable()
-        var block = try Biscuit.DatalogBlock("user($x) <- member($x, $team), $team == \"foo\";")
-        block.attachToBiscuit(interner: &interner, context: nil)
-        XCTAssertEqual(block.version, 6)
+        let block = try Biscuit.DatalogBlock("user($x) <- member($x, $team), $team == \"foo\";")
         XCTAssertEqual(block.context, nil)
         XCTAssert(block.facts.isEmpty)
         XCTAssert(block.checks.isEmpty)
         XCTAssert(block.trusted.isEmpty)
-        XCTAssert(block.publicKeys.isEmpty)
 
-        XCTAssertEqual(block.symbols, ["x", "foo"])
         XCTAssertEqual(block.rules.count, 1)
         let rule = block.rules[0]
         XCTAssert(rule.trusted.isEmpty)
@@ -128,15 +103,10 @@ final class BiscuitsTests: XCTestCase {
     }
 
     func testDatalogBlockWithScope() throws {
-        var interner = BlockInternmentTable()
-        var block = try Biscuit.DatalogBlock("trusting previous; check if user(1234);")
-        block.attachToBiscuit(interner: &interner, context: nil)
-        XCTAssertEqual(block.version, 6)
+        let block = try Biscuit.DatalogBlock("trusting previous; check if user(1234);")
         XCTAssertEqual(block.context, nil)
         XCTAssert(block.facts.isEmpty)
         XCTAssert(block.rules.isEmpty)
-        XCTAssert(block.publicKeys.isEmpty)
-        XCTAssert(block.symbols.isEmpty)
 
         XCTAssertEqual(block.trusted, [.previous])
         XCTAssertEqual(block.checks.count, 1)
@@ -153,16 +123,10 @@ final class BiscuitsTests: XCTestCase {
     }
 
     func testDatalogBlockWithRuleWithScope() throws {
-        var interner = BlockInternmentTable()
-        var block = try Biscuit.DatalogBlock("check if user(1234) trusting authority;")
-        block.attachToBiscuit(interner: &interner, context: nil)
-        XCTAssertEqual(block.version, 6)
+        let block = try Biscuit.DatalogBlock("check if user(1234) trusting authority;")
         XCTAssertEqual(block.context, nil)
         XCTAssert(block.facts.isEmpty)
         XCTAssert(block.rules.isEmpty)
-        XCTAssert(block.publicKeys.isEmpty)
-        XCTAssert(block.symbols.isEmpty)
-        XCTAssert(block.trusted.isEmpty)
 
         XCTAssertEqual(block.checks.count, 1)
         let check = block.checks[0]
@@ -178,22 +142,17 @@ final class BiscuitsTests: XCTestCase {
     }
 
     func testDatalogBlockWithEd25519Scope() throws {
-        var interner = BlockInternmentTable()
-        var block = try Biscuit.DatalogBlock(
+        let block = try Biscuit.DatalogBlock(
             """
                 trusting ed25519/0605d9692dd565fa8d70419081e032638fbc6dff5d96d14aeab49bc36a46d6a2;
                 check if user(1234);
             """
         )
-        block.attachToBiscuit(interner: &interner, context: nil)
-        XCTAssertEqual(block.version, 6)
         XCTAssertEqual(block.context, nil)
         XCTAssert(block.facts.isEmpty)
         XCTAssert(block.rules.isEmpty)
-        XCTAssert(block.symbols.isEmpty)
 
         XCTAssertEqual(block.trusted.count, 1)
-        XCTAssertEqual(block.publicKeys.count, 1)
         XCTAssertEqual(block.checks.count, 1)
         let check = block.checks[0]
         XCTAssertEqual(check.kind, .checkIf)
@@ -207,31 +166,24 @@ final class BiscuitsTests: XCTestCase {
     }
 
     func testBiscuitConstructionFromString() throws {
-        var interner = BlockInternmentTable()
         let key = P256.Signing.PrivateKey()
-        var block = try Biscuit.DatalogBlock("user(1234);")
-        block.attachToBiscuit(interner: &interner, context: nil)
+        let block = try Biscuit.DatalogBlock("user(1234);")
         let biscuit = try Biscuit(authorityBlock: "user(1234);", rootKey: key)
         XCTAssertEqual(biscuit.rootKeyID, nil)
         XCTAssert(biscuit.attenuations.isEmpty)
 
         let authority = biscuit.authority
         XCTAssertEqual(authority.nextKey.algorithm, .ed25519)
-        XCTAssertEqual(authority.datalog.version, block.version)
-        XCTAssertEqual(authority.datalog.symbols, block.symbols)
         XCTAssertEqual(authority.datalog.context, block.context)
         XCTAssertEqual(authority.datalog.checks, block.checks)
         XCTAssertEqual(authority.datalog.facts, block.facts)
         XCTAssertEqual(authority.datalog.rules, block.rules)
         XCTAssertEqual(authority.datalog.trusted, block.trusted)
-        XCTAssert(authority.datalog.publicKeys.isEmpty)
     }
 
     func testBiscuitConstructionFromDSL() throws {
-        var interner = BlockInternmentTable()
         let key = P256.Signing.PrivateKey()
-        var block = try Biscuit.DatalogBlock("user(1234);")
-        block.attachToBiscuit(interner: &interner, context: nil)
+        let block = try Biscuit.DatalogBlock("user(1234);")
         let biscuit = try Biscuit(rootKey: key) {
             Fact("user", 1234)
         }
@@ -240,45 +192,35 @@ final class BiscuitsTests: XCTestCase {
 
         let authority = biscuit.authority
         XCTAssertEqual(authority.nextKey.algorithm, .ed25519)
-        XCTAssertEqual(authority.datalog.version, block.version)
-        XCTAssertEqual(authority.datalog.symbols, block.symbols)
         XCTAssertEqual(authority.datalog.context, block.context)
         XCTAssertEqual(authority.datalog.checks, block.checks)
         XCTAssertEqual(authority.datalog.facts, block.facts)
         XCTAssertEqual(authority.datalog.rules, block.rules)
         XCTAssertEqual(authority.datalog.trusted, block.trusted)
-        XCTAssert(authority.datalog.publicKeys.isEmpty)
     }
 
     func testBiscuitAttenuationFromString() throws {
-        var interner = BlockInternmentTable()
         let key = P256.Signing.PrivateKey()
         let biscuit = try Biscuit(authorityBlock: "user(1234);", rootKey: key)
-        var attenuation = try Biscuit.DatalogBlock("check if read(\"/foo\");")
-        attenuation.attachToBiscuit(interner: &interner, context: nil)
+        let attenuation = try Biscuit.DatalogBlock("check if read(\"/foo\");")
         let attenuated = try biscuit.attenuated(using: "check if read(\"/foo\");", algorithm: .secp256r1)
         XCTAssertEqual(attenuated.attenuations.count, 1)
 
         let attenuation_block = attenuated.attenuations[0]
         XCTAssertEqual(attenuation_block.nextKey.algorithm, .secp256r1)
-        XCTAssertEqual(attenuation_block.datalog.version, attenuation.version)
-        XCTAssertEqual(attenuation_block.datalog.symbols, attenuation.symbols)
         XCTAssertEqual(attenuation_block.datalog.context, attenuation.context)
         XCTAssertEqual(attenuation_block.datalog.checks, attenuation.checks)
         XCTAssertEqual(attenuation_block.datalog.facts, attenuation.facts)
         XCTAssertEqual(attenuation_block.datalog.rules, attenuation.rules)
         XCTAssertEqual(attenuation_block.datalog.trusted, attenuation.trusted)
-        XCTAssert(attenuation_block.datalog.publicKeys.isEmpty)
     }
 
     func testBiscuitAttenuationFromDSL() throws {
-        var interner = BlockInternmentTable()
         let key = P256.Signing.PrivateKey()
         let biscuit = try Biscuit(rootKey: key) {
             Fact("user", 1234)
         }
-        var attenuation = try Biscuit.DatalogBlock("check if read(\"/foo\");")
-        attenuation.attachToBiscuit(interner: &interner, context: nil)
+        let attenuation = try Biscuit.DatalogBlock("check if read(\"/foo\");")
         let attenuated = try biscuit.attenuated(algorithm: .secp256r1) {
             Check.checkIf { Predicate("read", "/foo") }
         }
@@ -286,14 +228,11 @@ final class BiscuitsTests: XCTestCase {
 
         let attenuation_block = attenuated.attenuations[0]
         XCTAssertEqual(attenuation_block.nextKey.algorithm, .secp256r1)
-        XCTAssertEqual(attenuation_block.datalog.version, attenuation.version)
-        XCTAssertEqual(attenuation_block.datalog.symbols, attenuation.symbols)
         XCTAssertEqual(attenuation_block.datalog.context, attenuation.context)
         XCTAssertEqual(attenuation_block.datalog.checks, attenuation.checks)
         XCTAssertEqual(attenuation_block.datalog.facts, attenuation.facts)
         XCTAssertEqual(attenuation_block.datalog.rules, attenuation.rules)
         XCTAssertEqual(attenuation_block.datalog.trusted, attenuation.trusted)
-        XCTAssert(attenuation_block.datalog.publicKeys.isEmpty)
     }
 
     func testThirdPartySymbolTables() throws {

--- a/Tests/BiscuitsTests/GenerationTests.swift
+++ b/Tests/BiscuitsTests/GenerationTests.swift
@@ -39,22 +39,18 @@ final class GenerationTests: XCTestCase {
         compareBlocks(expected.authority.datalog, biscuit.authority.datalog)
         XCTAssertEqual(expected.attenuations.count, biscuit.attenuations.count)
         var previous = biscuit.authority
-        for (idx, (expected, block)) in zip(expected.attenuations, biscuit.attenuations).enumerated() {
+        for (expected, block) in zip(expected.attenuations, biscuit.attenuations) {
             XCTAssertEqual(expected.signedByThirdParty, block.signedByThirdParty)
             compareBlocks(expected.datalog, block.datalog)
 
-            let interner = biscuit.interner.blockTable(for: idx + 1)
-            let signatureInput = try block.signatureInput(interner: interner, lastSig: previous.signature)
+            let signatureInput = block.signatureInput(lastSig: previous.signature)
             XCTAssert(previous.nextKey.isValidSignature(block.signature, for: signatureInput))
             if let externalSignature = block.externalSignature {
-                try externalSignature.isValidSignature(for: block, lastSig: previous.signature, interner: interner)
+                try externalSignature.isValidSignature(for: block, lastSig: previous.signature)
             }
             previous = block
         }
-        try biscuit.proof.isValidProof(
-            for: previous,
-            interner: biscuit.interner.blockTable(for: biscuit.attenuations.count)
-        )
+        try biscuit.proof.isValidProof(for: previous)
 
         let serialized = try biscuit.serializedData()
         let deserialized = try Biscuit(serializedData: serialized, rootKey: rootPublicKey)
@@ -62,8 +58,6 @@ final class GenerationTests: XCTestCase {
     }
 
     func compareBlocks(_ lhs: Biscuit.DatalogBlock, _ rhs: Biscuit.DatalogBlock) {
-        XCTAssertEqual(lhs.symbols, rhs.symbols)
-        XCTAssertEqual(lhs.publicKeys, rhs.publicKeys)
         XCTAssertEqual(lhs.trusted, rhs.trusted)
         XCTAssertEqual(lhs.context, rhs.context)
         XCTAssertEqual(lhs.facts, rhs.facts)


### PR DESCRIPTION
Currently, the Swift library does not keep a serialized representation of the Datalog contents of blocks, instead generating one on the fly when it is needed (for signature verification and to serialize the token). This is problematic because the serialization of a block is non-canonical and there are multiple valid serializations for the same block (which will not all pass signature verification). The current behavior is a mistake I made when implementing the library.

This PR changes the behavior so that the `Biscuit.Block` type contains a `DatalogBlock` (the logical representation of its Datalog contents), a binary `serializedDatalog` field which is a valid serialization of that DatalogBlock, and the signatures on that serialization. The constructors for `Biscuit.Block` maintain the invariant that the serialization is a valid representation of the DatalogBlock by deriving one from the other and not allowing either to change after construction.

This also enables other simplifications throughout the library. We no longer need to keep the internment tables for third party blocks around after serialization/deserialization, so we just keep the single, main internment table which will be used in attenuation. We don't need separate internment/serialization methods on the datalog types, because they are now always interned and serialized at the same time. Several (internal) functions that could previous throw errors now cannot.