### PR TITLE
Fix handling of base64url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# `2.0.1`
+
+- Fix bug in base64url encoding/decoding: now accept base64url data with our without padding bytes
+  and emit data without padding bytes (previously always required padding bytes)
+
 # `2.0.0`
 
 - Fix platform minimum versions being too low for iOS, tvOS, and watchOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # `2.0.1`
 
-- Fix bug in base64url encoding/decoding: now accept base64url data with or without padding bytes
-  and emit data without padding bytes (previously always required padding bytes)
+- Fix bug in base64url decoding: now accept base64url data with or without padding bytes
 
 # `2.0.0`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # `2.0.1`
 
-- Fix bug in base64url encoding/decoding: now accept base64url data with our without padding bytes
+- Fix bug in base64url encoding/decoding: now accept base64url data with or without padding bytes
   and emit data without padding bytes (previously always required padding bytes)
 
 # `2.0.0`

--- a/Sources/Biscuits/Base64.swift
+++ b/Sources/Biscuits/Base64.swift
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// This file handles base64url encoding because Swift historically only supported non-urlsafe
+// base64. Swift 6.3 added support for encoding to urlsafe base64, but not decoding.
+
+import Foundation
+
+func base64URLEncoded(_ data: Data) -> String {
+    #if compiler(>=6.3)
+    if #available(macOS 26.4, iOS 26.4, tvOS 26.4, watchOS 26.4, visionOS 26.4, *) {
+        return data.base64EncodedString(options: [.base64URLAlphabet, .omitPaddingCharacter])
+    } else {
+        return manualBase64URLEncoded(data)
+    }
+    #else
+    return manualBase64URLEncoded(data)
+    #endif
+}
+
+func base64URLDecoded(_ data: String) throws -> Data {
+    return try manualBase64URLDecoded(data)
+}
+
+fileprivate func manualBase64URLEncoded(_ data: Data) -> String {
+    data.base64EncodedString()
+        .replacingOccurrences(of: "+", with: "-")
+        .replacingOccurrences(of: "/", with: "_")
+        .replacingOccurrences(of: "=", with: "")
+}
+
+fileprivate func manualBase64URLDecoded(_ data: String) throws -> Data {
+    var base64Encoded = data
+        .replacingOccurrences(of: "-", with: "+")
+        .replacingOccurrences(of: "_", with: "/")
+    
+    // Swift's base64 decoding requires padding bytes whereas base64url usually does not contain
+    // padding bytes.
+    if base64Encoded.count % 4 != 0 {
+        base64Encoded += String(repeating: "=", count: 4 - (base64Encoded.count % 4))
+    }
+    guard let data = Data(base64Encoded: base64Encoded) else {
+        throw Biscuit.ValidationError.invalidBase64URLString
+    }
+
+    return data
+}

--- a/Sources/Biscuits/Base64.swift
+++ b/Sources/Biscuits/Base64.swift
@@ -11,7 +11,7 @@ import Foundation
 func base64URLEncoded(_ data: Data) -> String {
     #if compiler(>=6.3)
     if #available(macOS 26.4, iOS 26.4, tvOS 26.4, watchOS 26.4, visionOS 26.4, *) {
-        return data.base64EncodedString(options: [.base64URLAlphabet, .omitPaddingCharacter])
+        return data.base64EncodedString(options: [.base64URLAlphabet])
     } else {
         return manualBase64URLEncoded(data)
     }
@@ -28,7 +28,6 @@ private func manualBase64URLEncoded(_ data: Data) -> String {
     data.base64EncodedString()
         .replacingOccurrences(of: "+", with: "-")
         .replacingOccurrences(of: "/", with: "_")
-        .replacingOccurrences(of: "=", with: "")
 }
 
 private func manualBase64URLDecoded(_ data: String) throws -> Data {

--- a/Sources/Biscuits/Base64.swift
+++ b/Sources/Biscuits/Base64.swift
@@ -21,21 +21,22 @@ func base64URLEncoded(_ data: Data) -> String {
 }
 
 func base64URLDecoded(_ data: String) throws -> Data {
-    return try manualBase64URLDecoded(data)
+    try manualBase64URLDecoded(data)
 }
 
-fileprivate func manualBase64URLEncoded(_ data: Data) -> String {
+private func manualBase64URLEncoded(_ data: Data) -> String {
     data.base64EncodedString()
         .replacingOccurrences(of: "+", with: "-")
         .replacingOccurrences(of: "/", with: "_")
         .replacingOccurrences(of: "=", with: "")
 }
 
-fileprivate func manualBase64URLDecoded(_ data: String) throws -> Data {
-    var base64Encoded = data
+private func manualBase64URLDecoded(_ data: String) throws -> Data {
+    var base64Encoded =
+        data
         .replacingOccurrences(of: "-", with: "+")
         .replacingOccurrences(of: "_", with: "/")
-    
+
     // Swift's base64 decoding requires padding bytes whereas base64url usually does not contain
     // padding bytes.
     if base64Encoded.count % 4 != 0 {

--- a/Sources/Biscuits/Biscuit.swift
+++ b/Sources/Biscuits/Biscuit.swift
@@ -168,16 +168,7 @@ public struct Biscuit: Sendable, Hashable {
     /// - Throws: Validation may throw a protobuf error or a `ValidationError` if
     /// base64url or the underlying data is not in the proper format or signatures are not valid
     public init<Key: PublicKey>(base64URLEncoded: String, getRootKey: (RootKeyID?) -> Key?) throws {
-        // Translate base64url into base64, ignoring padding, as defined in RFC4648.
-        let base64Encoded =
-            base64URLEncoded
-            .replacingOccurrences(of: "-", with: "+")
-            .replacingOccurrences(of: "_", with: "/")
-
-        guard let data = Data(base64Encoded: base64Encoded) else {
-            throw ValidationError.invalidBase64URLString
-        }
-
+        let data = try Biscuits.base64URLDecoded(base64URLEncoded)
         try self.init(serializedData: data, getRootKey: getRootKey)
     }
 
@@ -415,12 +406,8 @@ public struct Biscuit: Sendable, Hashable {
     /// - Returns: the base64url encoded representation of this Biscuit
     /// - Throws: May thow an error if protobuf serialization fails
     public func base64URLEncoded() throws -> String {
-        let base64Encoded = try self.serializedData().base64EncodedString()
-        // Translate base64 into base64url, ignoring padding, as defined in RFC4648.
-        return
-            base64Encoded
-            .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
+        let data = try self.serializedData()
+        return Biscuits.base64URLEncoded(data)
     }
 
     /// Whether or not this Biscuit has been sealed

--- a/Sources/Biscuits/UnverifiedBiscuit.swift
+++ b/Sources/Biscuits/UnverifiedBiscuit.swift
@@ -56,16 +56,7 @@ public struct UnverifiedBiscuit: Sendable, Hashable {
     /// - Throws: Validation may throw a protobuf error or a `ValidationError` if base64url or the
     /// underlying data is not in the proper format
     public init(base64URLEncoded: String) throws {
-        // Translate base64url into base64, ignoring padding, as defined in RFC4648.
-        let base64Encoded =
-            base64URLEncoded
-            .replacingOccurrences(of: "-", with: "+")
-            .replacingOccurrences(of: "_", with: "/")
-
-        guard let data = Data(base64Encoded: base64Encoded) else {
-            throw Biscuit.ValidationError.invalidBase64URLString
-        }
-
+        let data = try Biscuits.base64URLDecoded(base64URLEncoded)
         try self.init(serializedData: data)
     }
 
@@ -287,12 +278,8 @@ public struct UnverifiedBiscuit: Sendable, Hashable {
     /// - Returns: the base64url encoded representation of this Biscuit
     /// - Throws: May thow an error if protobuf serialization fails
     public func base64URLEncoded() throws -> String {
-        let base64Encoded = try self.serializedData().base64EncodedString()
-        // Translate base64 into base64url, ignoring padding, as defined in RFC4648.
-        return
-            base64Encoded
-            .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
+        let data = try self.serializedData()
+        return Biscuits.base64URLEncoded(data)
     }
 
     var proto: Biscuit_Format_Schema_Biscuit {

--- a/Tests/BiscuitsTests/Base64Tests.swift
+++ b/Tests/BiscuitsTests/Base64Tests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import XCTest
+
+@testable import Biscuits
+
+final class Base64Tests: XCTestCase {
+    func testBase64UrlEncoding() {
+        let cases: [(Data, String)] = [
+            (Data([]), ""),
+            (Data([0x66]), "Zg"),
+            (Data([0x66, 0x6f, 0x6f]), "Zm9v"),
+            (Data([0xfb]), "-w"),
+            (Data([0xff]), "_w"),
+            (Data([0xfb, 0xff, 0xfe]), "-__-"),
+            (Data([0x00, 0x00, 0x00]), "AAAA"),
+            (Data("Hello, World!".utf8), "SGVsbG8sIFdvcmxkIQ"),
+        ]
+        for (input, expected) in cases {
+            XCTAssertEqual(base64URLEncoded(input), expected)
+        }
+    }
+
+    func testBase64UrlDecoding() {
+        let cases: [(Data, String)] = [
+            (Data([]), ""),
+            (Data([0x66]), "Zg"),
+            (Data([0x66, 0x6f, 0x6f]), "Zm9v"),
+            (Data([0xfb]), "-w"),
+            (Data([0xff]), "_w"),
+            (Data([0xfb, 0xff, 0xfe]), "-__-"),
+            (Data([0x00, 0x00, 0x00]), "AAAA"),
+            (Data("Hello, World!".utf8), "SGVsbG8sIFdvcmxkIQ"),
+        ]
+        for (expected, input) in cases {
+            try XCTAssertEqual(base64URLDecoded(input), expected)
+        }
+    }
+}

--- a/Tests/BiscuitsTests/Base64Tests.swift
+++ b/Tests/BiscuitsTests/Base64Tests.swift
@@ -7,13 +7,13 @@ final class Base64Tests: XCTestCase {
     func testBase64UrlEncoding() {
         let cases: [(Data, String)] = [
             (Data([]), ""),
-            (Data([0x66]), "Zg"),
+            (Data([0x66]), "Zg=="),
             (Data([0x66, 0x6f, 0x6f]), "Zm9v"),
-            (Data([0xfb]), "-w"),
-            (Data([0xff]), "_w"),
+            (Data([0xfb]), "-w=="),
+            (Data([0xff]), "_w=="),
             (Data([0xfb, 0xff, 0xfe]), "-__-"),
             (Data([0x00, 0x00, 0x00]), "AAAA"),
-            (Data("Hello, World!".utf8), "SGVsbG8sIFdvcmxkIQ"),
+            (Data("Hello, World!".utf8), "SGVsbG8sIFdvcmxkIQ=="),
         ]
         for (input, expected) in cases {
             XCTAssertEqual(base64URLEncoded(input), expected)
@@ -24,12 +24,16 @@ final class Base64Tests: XCTestCase {
         let cases: [(Data, String)] = [
             (Data([]), ""),
             (Data([0x66]), "Zg"),
+            (Data([0x66]), "Zg=="),
             (Data([0x66, 0x6f, 0x6f]), "Zm9v"),
             (Data([0xfb]), "-w"),
+            (Data([0xfb]), "-w=="),
             (Data([0xff]), "_w"),
+            (Data([0xff]), "_w=="),
             (Data([0xfb, 0xff, 0xfe]), "-__-"),
             (Data([0x00, 0x00, 0x00]), "AAAA"),
             (Data("Hello, World!".utf8), "SGVsbG8sIFdvcmxkIQ"),
+            (Data("Hello, World!".utf8), "SGVsbG8sIFdvcmxkIQ=="),
         ]
         for (expected, input) in cases {
             try XCTAssertEqual(base64URLDecoded(input), expected)

--- a/Tests/BiscuitsTests/BiscuitsTests.swift
+++ b/Tests/BiscuitsTests/BiscuitsTests.swift
@@ -316,7 +316,7 @@ final class BiscuitsTests: XCTestCase {
         // Generated with biscuit-cli, by running this (with private key from above `biscuit keypair` command):
         //   $ echo 'flavor("buttermilk")' | biscuit generate --private-key "ed25519/ffedda2d87d1735763a707838833f3539b4a0d6cd53c6ded31875162ca0b8e83" -
         let encodedBiscuit =
-            "EowBCiIKBmZsYXZvcgoKYnV0dGVybWlsaxgDIgoKCAiACBIDGIEIEiQIABIgl0EWCFozow3RiEOtTcpY0O7ZADutOWZZ3wTJ0QKx5XMaQI4VPeolN94zLHxvP0JDvSuBeMe3wGmkcsD32u2wGegMdQiK78hiNclVjUr_9MOlHEr72kPIPiTQNXmk6AvlEggiIgogRWH7vgsJR3d8xreGt_8Trodp4x9eRZSgbBvDQzUeh9s"
+            "EowBCiIKBmZsYXZvcgoKYnV0dGVybWlsaxgDIgoKCAiACBIDGIEIEiQIABIgl0EWCFozow3RiEOtTcpY0O7ZADutOWZZ3wTJ0QKx5XMaQI4VPeolN94zLHxvP0JDvSuBeMe3wGmkcsD32u2wGegMdQiK78hiNclVjUr_9MOlHEr72kPIPiTQNXmk6AvlEggiIgogRWH7vgsJR3d8xreGt_8Trodp4x9eRZSgbBvDQzUeh9s="
 
         // Make sure we can construct the biscuit, and verify it was signed with our private key.
         let biscuit = try Biscuit(

--- a/Tests/BiscuitsTests/BiscuitsTests.swift
+++ b/Tests/BiscuitsTests/BiscuitsTests.swift
@@ -316,7 +316,7 @@ final class BiscuitsTests: XCTestCase {
         // Generated with biscuit-cli, by running this (with private key from above `biscuit keypair` command):
         //   $ echo 'flavor("buttermilk")' | biscuit generate --private-key "ed25519/ffedda2d87d1735763a707838833f3539b4a0d6cd53c6ded31875162ca0b8e83" -
         let encodedBiscuit =
-            "EowBCiIKBmZsYXZvcgoKYnV0dGVybWlsaxgDIgoKCAiACBIDGIEIEiQIABIgl0EWCFozow3RiEOtTcpY0O7ZADutOWZZ3wTJ0QKx5XMaQI4VPeolN94zLHxvP0JDvSuBeMe3wGmkcsD32u2wGegMdQiK78hiNclVjUr_9MOlHEr72kPIPiTQNXmk6AvlEggiIgogRWH7vgsJR3d8xreGt_8Trodp4x9eRZSgbBvDQzUeh9s="
+            "EowBCiIKBmZsYXZvcgoKYnV0dGVybWlsaxgDIgoKCAiACBIDGIEIEiQIABIgl0EWCFozow3RiEOtTcpY0O7ZADutOWZZ3wTJ0QKx5XMaQI4VPeolN94zLHxvP0JDvSuBeMe3wGmkcsD32u2wGegMdQiK78hiNclVjUr_9MOlHEr72kPIPiTQNXmk6AvlEggiIgogRWH7vgsJR3d8xreGt_8Trodp4x9eRZSgbBvDQzUeh9s"
 
         // Make sure we can construct the biscuit, and verify it was signed with our private key.
         let biscuit = try Biscuit(


### PR DESCRIPTION
This fixes the handling of base64url by accepting base64url without padding (though also accepting *with* padding) and producing without padding - the standard for base64url. Previously, the library always produced base64url with padding bytes and would not accept base64url without padding bytes.

Additionally, in Swift 6.3 there is now built-in support in Foundation for base64url encoding (though not decoding), so we opportunistically use that implementation (which should be faster) when building for Swift 6.3 and running on a platform with the correct Foundation.

Because of the compatibility complexity of base64url in Swift, we've moved the code to its own module and added tests.
